### PR TITLE
ci: split monolithic CI into per-project independent workflows

### DIFF
--- a/.github/workflows/ci-daily-context-ai.yml
+++ b/.github/workflows/ci-daily-context-ai.yml
@@ -1,10 +1,16 @@
-name: CI
+name: CI — daily-context-ai
 
 on:
   push:
     branches: [main]
+    paths:
+      - 'ai-architect/daily-context-ai/**'
+      - '.github/workflows/ci-daily-context-ai.yml'
   pull_request:
     branches: [main]
+    paths:
+      - 'ai-architect/daily-context-ai/**'
+      - '.github/workflows/ci-daily-context-ai.yml'
 
 jobs:
   backend:
@@ -26,7 +32,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: test-reports
+          name: daily-context-ai-test-reports
           path: ai-architect/daily-context-ai/**/build/reports/tests/
 
   frontend:

--- a/.github/workflows/ci-rag-report-analyzer.yml
+++ b/.github/workflows/ci-rag-report-analyzer.yml
@@ -1,0 +1,36 @@
+name: CI — rag-report-analyzer
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'ai-architect/rag-report-analyzer/**'
+      - '.github/workflows/ci-rag-report-analyzer.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'ai-architect/rag-report-analyzer/**'
+      - '.github/workflows/ci-rag-report-analyzer.yml'
+
+jobs:
+  backend:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ai-architect/rag-report-analyzer/backend
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 25
+          cache: gradle
+      - name: Run tests
+        run: ./gradlew test --no-daemon
+      - name: Upload test reports
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: rag-report-analyzer-test-reports
+          path: ai-architect/rag-report-analyzer/backend/build/reports/tests/


### PR DESCRIPTION
## Summary
- Replaces single `ci.yml` with two path-filtered workflow files
- Each project now triggers CI builds independently based on changed paths

## Changes

| Workflow | Triggers on |
|---|---|
| `ci-daily-context-ai.yml` | `ai-architect/daily-context-ai/**` |
| `ci-rag-report-analyzer.yml` | `ai-architect/rag-report-analyzer/**` |

Both workflows also re-run when their own `.yml` file is modified.

## Why
Prevents unrelated project changes from triggering unnecessary builds — e.g. touching `rag-report-analyzer` no longer runs `daily-context-ai` backend tests and vice versa.

## Test plan
- [ ] Push a change under `ai-architect/daily-context-ai/` — only `CI — daily-context-ai` runs
- [ ] Push a change under `ai-architect/rag-report-analyzer/` — only `CI — rag-report-analyzer` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)