### PR TITLE
fix: correct path filter in ci-rag-report-analyzer workflow

### DIFF
--- a/.github/workflows/ci-rag-report-analyzer.yml
+++ b/.github/workflows/ci-rag-report-analyzer.yml
@@ -4,12 +4,12 @@ on:
   push:
     branches: [main]
     paths:
-      - 'ai-architect/rag-report-analyzer/**'
+      - 'rag-report-analyzer/**'
       - '.github/workflows/ci-rag-report-analyzer.yml'
   pull_request:
     branches: [main]
     paths:
-      - 'ai-architect/rag-report-analyzer/**'
+      - 'rag-report-analyzer/**'
       - '.github/workflows/ci-rag-report-analyzer.yml'
 
 jobs:
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ai-architect/rag-report-analyzer/backend
+        working-directory: rag-report-analyzer/backend
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -33,4 +33,4 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: rag-report-analyzer-test-reports
-          path: ai-architect/rag-report-analyzer/backend/build/reports/tests/
+          path: rag-report-analyzer/backend/build/reports/tests/


### PR DESCRIPTION
## Problem
`ci-rag-report-analyzer.yml` was never triggering because the path filter pointed to `ai-architect/rag-report-analyzer/**` but on `main` the project is at `rag-report-analyzer/` (root level).

## Fix
| | Before | After |
|---|---|---|
| `paths` trigger | `ai-architect/rag-report-analyzer/**` | `rag-report-analyzer/**` |
| `working-directory` | `ai-architect/rag-report-analyzer/backend` | `rag-report-analyzer/backend` |
| artifact `path` | `ai-architect/rag-report-analyzer/backend/build/...` | `rag-report-analyzer/backend/build/...` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)