### PR TITLE
feat #2(rag-financial-report): Phase 4 — Structured Metrics Extraction

### DIFF
--- a/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/domain/model/FinancialMetrics.java
+++ b/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/domain/model/FinancialMetrics.java
@@ -1,0 +1,28 @@
+package com.aiarchitect.rag.report.domain.model;
+
+/**
+ * Extracted financial metrics for a specific company reporting period.
+ *
+ * <p>All monetary values are in millions USD. {@code null} means the metric
+ * was not found in the report excerpts provided to the LLM.
+ *
+ * @param ticker             company ticker symbol (e.g. "NVDA")
+ * @param year               fiscal year (e.g. 2025)
+ * @param quarter            reporting period: "Q1", "Q2", "Q3", "Q4", or "Annual"
+ * @param revenue            total revenue, millions USD
+ * @param netIncome          net income, millions USD
+ * @param eps                diluted earnings per share
+ * @param operatingCashFlow  operating cash flow, millions USD
+ * @param debtToEquity       total debt / total equity ratio
+ */
+public record FinancialMetrics(
+        String ticker,
+        int year,
+        String quarter,
+        Double revenue,
+        Double netIncome,
+        Double eps,
+        Double operatingCashFlow,
+        Double debtToEquity
+) {
+}

--- a/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/domain/model/graph/GraphEdge.java
+++ b/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/domain/model/graph/GraphEdge.java
@@ -1,0 +1,11 @@
+package com.aiarchitect.rag.report.domain.model.graph;
+
+/**
+ * A directed edge in the financial knowledge graph (D3-compatible).
+ *
+ * @param source source node id
+ * @param target target node id
+ * @param label  relationship label (e.g. "HAS_REPORT", "HAS_METRIC")
+ */
+public record GraphEdge(String source, String target, String label) {
+}

--- a/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/domain/model/graph/GraphNode.java
+++ b/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/domain/model/graph/GraphNode.java
@@ -1,0 +1,13 @@
+package com.aiarchitect.rag.report.domain.model.graph;
+
+import java.util.Map;
+
+/**
+ * A node in the financial knowledge graph (D3-compatible).
+ *
+ * @param id   unique node identifier
+ * @param type node type: "company", "report", or "metric"
+ * @param data additional display data (name, value, unit, etc.)
+ */
+public record GraphNode(String id, String type, Map<String, Object> data) {
+}

--- a/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/domain/model/graph/MetricsGraph.java
+++ b/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/domain/model/graph/MetricsGraph.java
@@ -1,0 +1,16 @@
+package com.aiarchitect.rag.report.domain.model.graph;
+
+import java.util.List;
+
+/**
+ * D3-compatible force-directed graph of financial metrics for a company.
+ *
+ * <p>Graph shape: {@code Company → Report → Metric}
+ * <ul>
+ *   <li>One "company" node per ticker
+ *   <li>One "report" node per (year, quarter)
+ *   <li>One "metric" node per non-null metric value per report
+ * </ul>
+ */
+public record MetricsGraph(List<GraphNode> nodes, List<GraphEdge> edges) {
+}

--- a/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/domain/port/in/MetricsExtractionFacade.java
+++ b/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/domain/port/in/MetricsExtractionFacade.java
@@ -1,0 +1,35 @@
+package com.aiarchitect.rag.report.domain.port.in;
+
+import com.aiarchitect.rag.report.domain.model.FinancialMetrics;
+import com.aiarchitect.rag.report.domain.model.graph.MetricsGraph;
+
+import java.util.Optional;
+
+/**
+ * Inbound port (use case): extract and query structured financial metrics.
+ */
+public interface MetricsExtractionFacade {
+
+    /**
+     * Retrieves relevant report chunks, extracts financial metrics using the LLM,
+     * and persists the result.
+     *
+     * @param ticker  company ticker (e.g. "NVDA") — must match ingested documents
+     * @param year    fiscal year
+     * @param quarter reporting period: "Q1", "Q2", "Q3", "Q4", or "Annual"
+     * @return extracted and persisted {@link FinancialMetrics}
+     */
+    FinancialMetrics extractAndSave(String ticker, int year, String quarter);
+
+    /**
+     * Returns previously extracted metrics for a specific period.
+     */
+    Optional<FinancialMetrics> getMetrics(String ticker, int year, String quarter);
+
+    /**
+     * Builds a D3-compatible knowledge graph of all metrics stored for a ticker.
+     *
+     * <p>Shape: {@code Company → Report → Metric} nodes + edges.
+     */
+    MetricsGraph getGraph(String ticker);
+}

--- a/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/domain/port/out/MetricsExtractionPort.java
+++ b/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/domain/port/out/MetricsExtractionPort.java
@@ -1,0 +1,27 @@
+package com.aiarchitect.rag.report.domain.port.out;
+
+import com.aiarchitect.rag.report.domain.model.FinancialMetrics;
+import org.springframework.ai.document.Document;
+
+import java.util.List;
+
+/**
+ * Outbound port: extracts structured {@link FinancialMetrics} from document chunks
+ * using an LLM.
+ *
+ * <p>The adapter is responsible for prompt assembly, structured output parsing
+ * (e.g. via {@code ChatClient.call().entity()}), and mapping to the domain record.
+ */
+public interface MetricsExtractionPort {
+
+    /**
+     * Extracts financial metrics from the provided context chunks.
+     *
+     * @param ticker  company ticker for metadata annotation
+     * @param year    fiscal year for metadata annotation
+     * @param quarter reporting period for metadata annotation
+     * @param chunks  document chunks to use as extraction context
+     * @return extracted metrics (fields may be null if not found in context)
+     */
+    FinancialMetrics extract(String ticker, int year, String quarter, List<Document> chunks);
+}

--- a/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/domain/port/out/ReportRepositoryPort.java
+++ b/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/domain/port/out/ReportRepositoryPort.java
@@ -1,0 +1,30 @@
+package com.aiarchitect.rag.report.domain.port.out;
+
+import com.aiarchitect.rag.report.domain.model.FinancialMetrics;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Outbound port: persists and queries extracted {@link FinancialMetrics}.
+ *
+ * <p>The concrete adapter uses Spring Data JPA + H2 (phases 1–5) and can be
+ * swapped for PostgreSQL in Phase 10 without touching the domain.
+ */
+public interface ReportRepositoryPort {
+
+    /**
+     * Persists or updates metrics for the given ticker/year/quarter.
+     */
+    FinancialMetrics save(FinancialMetrics metrics);
+
+    /**
+     * Finds previously saved metrics for a specific reporting period.
+     */
+    Optional<FinancialMetrics> findByTickerAndYearAndQuarter(String ticker, int year, String quarter);
+
+    /**
+     * Returns all stored metrics for a ticker across all periods, ordered by year/quarter.
+     */
+    List<FinancialMetrics> findAllByTicker(String ticker);
+}

--- a/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/domain/service/MetricsExtractionService.java
+++ b/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/domain/service/MetricsExtractionService.java
@@ -1,0 +1,106 @@
+package com.aiarchitect.rag.report.domain.service;
+
+import com.aiarchitect.rag.report.domain.model.FinancialMetrics;
+import com.aiarchitect.rag.report.domain.model.graph.GraphEdge;
+import com.aiarchitect.rag.report.domain.model.graph.GraphNode;
+import com.aiarchitect.rag.report.domain.model.graph.MetricsGraph;
+import com.aiarchitect.rag.report.domain.port.in.MetricsExtractionFacade;
+import com.aiarchitect.rag.report.domain.port.out.DocumentStorePort;
+import com.aiarchitect.rag.report.domain.port.out.MetricsExtractionPort;
+import com.aiarchitect.rag.report.domain.port.out.ReportRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.document.Document;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Orchestrates structured metrics extraction from ingested report documents.
+ *
+ * <pre>
+ * Phase 4: Structured Metrics Extraction
+ *  1. Retrieve chunks scoped to ticker+year (financial-keyword query)
+ *  2. Call MetricsExtractionPort — LLM returns structured FinancialMetrics
+ *  3. Persist via ReportRepositoryPort
+ *  4. Build D3 graph on demand from persisted data
+ * </pre>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MetricsExtractionService implements MetricsExtractionFacade {
+
+    public static final int METRICS_TOP_K = 10;
+
+    // Broad financial query to pull in chunks covering all key metrics
+    public static final String METRICS_QUERY =
+            "revenue net income earnings per share operating cash flow debt equity";
+
+    private final DocumentStorePort documentStorePort;
+    private final MetricsExtractionPort metricsExtractionPort;
+    private final ReportRepositoryPort reportRepositoryPort;
+
+    @Override
+    public FinancialMetrics extractAndSave(String ticker, int year, String quarter) {
+        log.info("Extracting metrics: ticker={}, year={}, quarter={}", ticker, year, quarter);
+
+        Map<String, Object> filter = Map.of("ticker", ticker, "year", year);
+        List<Document> chunks = documentStorePort.similaritySearch(METRICS_QUERY, METRICS_TOP_K, filter);
+
+        log.debug("Retrieved {} chunks for metrics extraction", chunks.size());
+
+        FinancialMetrics metrics = metricsExtractionPort.extract(ticker, year, quarter, chunks);
+        FinancialMetrics saved = reportRepositoryPort.save(metrics);
+
+        log.info("Saved metrics for {}/{}/{}: revenue={}, netIncome={}",
+                ticker, year, quarter, saved.revenue(), saved.netIncome());
+        return saved;
+    }
+
+    @Override
+    public Optional<FinancialMetrics> getMetrics(String ticker, int year, String quarter) {
+        return reportRepositoryPort.findByTickerAndYearAndQuarter(ticker, year, quarter);
+    }
+
+    @Override
+    public MetricsGraph getGraph(String ticker) {
+        List<FinancialMetrics> allMetrics = reportRepositoryPort.findAllByTicker(ticker);
+
+        List<GraphNode> nodes = new ArrayList<>();
+        List<GraphEdge> edges = new ArrayList<>();
+
+        // Company node
+        nodes.add(new GraphNode(ticker, "company", Map.of("name", ticker)));
+
+        for (FinancialMetrics m : allMetrics) {
+            String reportId = "%s-%d-%s".formatted(ticker, m.year(), m.quarter());
+
+            // Report node
+            nodes.add(new GraphNode(reportId, "report",
+                    Map.of("year", m.year(), "quarter", m.quarter())));
+            edges.add(new GraphEdge(ticker, reportId, "HAS_REPORT"));
+
+            // Metric nodes — only for non-null values
+            addMetricNode(nodes, edges, reportId, "revenue", m.revenue(), "M USD");
+            addMetricNode(nodes, edges, reportId, "netIncome", m.netIncome(), "M USD");
+            addMetricNode(nodes, edges, reportId, "eps", m.eps(), "USD/share");
+            addMetricNode(nodes, edges, reportId, "operatingCashFlow", m.operatingCashFlow(), "M USD");
+            addMetricNode(nodes, edges, reportId, "debtToEquity", m.debtToEquity(), "ratio");
+        }
+
+        return new MetricsGraph(nodes, edges);
+    }
+
+    private void addMetricNode(List<GraphNode> nodes, List<GraphEdge> edges,
+                                String reportId, String name, Double value, String unit) {
+        if (value == null) return;
+        String metricId = "%s-%s".formatted(reportId, name);
+        nodes.add(new GraphNode(metricId, "metric",
+                Map.of("name", name, "value", value, "unit", unit)));
+        edges.add(new GraphEdge(reportId, metricId, "HAS_METRIC"));
+    }
+}

--- a/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/infrastructure/adapter/in/rest/MetricsController.java
+++ b/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/infrastructure/adapter/in/rest/MetricsController.java
@@ -1,0 +1,60 @@
+package com.aiarchitect.rag.report.infrastructure.adapter.in.rest;
+
+import com.aiarchitect.rag.report.domain.model.FinancialMetrics;
+import com.aiarchitect.rag.report.domain.model.graph.MetricsGraph;
+import com.aiarchitect.rag.report.domain.port.in.MetricsExtractionFacade;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Inbound adapter: exposes structured metrics extraction and retrieval over HTTP.
+ *
+ * <pre>
+ * POST /api/v1/metrics/extract?ticker=NVDA&year=2025&quarter=Annual
+ *   → triggers LLM extraction from ingested chunks, persists result
+ *
+ * GET /api/v1/metrics/{ticker}/{year}/{quarter}
+ *   → returns previously extracted metrics (404 if not yet extracted)
+ *
+ * GET /api/v1/metrics/graph/{ticker}
+ *   → returns D3-compatible knowledge graph: Company → Report → Metric
+ * </pre>
+ *
+ * <p>Requires documents to be ingested first (Phase 1+2 pipeline).
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/metrics")
+@RequiredArgsConstructor
+public class MetricsController {
+
+    private final MetricsExtractionFacade metricsExtractionFacade;
+
+    @PostMapping("/extract")
+    public FinancialMetrics extract(
+            @RequestParam String ticker,
+            @RequestParam int year,
+            @RequestParam String quarter) {
+        log.info("POST /api/v1/metrics/extract — ticker={}, year={}, quarter={}", ticker, year, quarter);
+        return metricsExtractionFacade.extractAndSave(ticker, year, quarter);
+    }
+
+    @GetMapping("/{ticker}/{year}/{quarter}")
+    public ResponseEntity<FinancialMetrics> getMetrics(
+            @PathVariable String ticker,
+            @PathVariable int year,
+            @PathVariable String quarter) {
+        log.info("GET /api/v1/metrics/{}/{}/{}", ticker, year, quarter);
+        return metricsExtractionFacade.getMetrics(ticker, year, quarter)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/graph/{ticker}")
+    public MetricsGraph getGraph(@PathVariable String ticker) {
+        log.info("GET /api/v1/metrics/graph/{}", ticker);
+        return metricsExtractionFacade.getGraph(ticker);
+    }
+}

--- a/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/infrastructure/adapter/out/ai/FinancialMetricsDto.java
+++ b/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/infrastructure/adapter/out/ai/FinancialMetricsDto.java
@@ -1,0 +1,29 @@
+package com.aiarchitect.rag.report.infrastructure.adapter.out.ai;
+
+import lombok.Data;
+
+/**
+ * DTO for Spring AI structured output ({@code ChatClient.call().entity(FinancialMetricsDto.class)}).
+ *
+ * <p>Spring AI's {@code BeanOutputConverter} generates a JSON schema from this class,
+ * injects it into the prompt as format instructions, and parses the LLM response.
+ * Kept in the infrastructure layer to avoid Jackson/Spring AI dependencies in the domain.
+ */
+@Data
+public class FinancialMetricsDto {
+
+    /** Total revenue in millions USD. Null if not found. */
+    private Double revenue;
+
+    /** Net income in millions USD. Null if not found. */
+    private Double netIncome;
+
+    /** Diluted earnings per share. Null if not found. */
+    private Double eps;
+
+    /** Operating cash flow in millions USD. Null if not found. */
+    private Double operatingCashFlow;
+
+    /** Total debt to total equity ratio. Null if not found. */
+    private Double debtToEquity;
+}

--- a/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/infrastructure/adapter/out/ai/SpringAiMetricsExtractionAdapter.java
+++ b/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/infrastructure/adapter/out/ai/SpringAiMetricsExtractionAdapter.java
@@ -1,0 +1,87 @@
+package com.aiarchitect.rag.report.infrastructure.adapter.out.ai;
+
+import com.aiarchitect.rag.report.domain.model.FinancialMetrics;
+import com.aiarchitect.rag.report.domain.port.out.MetricsExtractionPort;
+import com.aiarchitect.rag.report.infrastructure.props.AiProviderProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.document.Document;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Outbound adapter: extracts structured financial metrics via the LLM.
+ *
+ * <p>Uses {@code ChatClient.call().entity(FinancialMetricsDto.class)} which internally:
+ * <ol>
+ *   <li>Generates a JSON schema from {@link FinancialMetricsDto}
+ *   <li>Appends format instructions to the prompt
+ *   <li>Parses the LLM response into the DTO
+ * </ol>
+ * Maps the DTO to the domain {@link FinancialMetrics} record.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SpringAiMetricsExtractionAdapter implements MetricsExtractionPort {
+
+    private final Map<String, ChatClient> chatClientsByProvider;
+    private final AiProviderProperties aiProviderProperties;
+
+    @Value("classpath:prompts/metrics-extraction.st")
+    private Resource systemPromptResource;
+
+    @Override
+    public FinancialMetrics extract(String ticker, int year, String quarter, List<Document> chunks) {
+        String provider = aiProviderProperties.active();
+        ChatClient client = chatClientsByProvider.get(provider);
+        if (client == null) {
+            throw new IllegalStateException(
+                    "LLM provider '%s' is not configured. Available: %s"
+                            .formatted(provider, chatClientsByProvider.keySet()));
+        }
+
+        String context = chunks.stream()
+                .map(doc -> "Source [page=%s]:\n%s".formatted(
+                        doc.getMetadata().getOrDefault("page_number", "?"),
+                        doc.getText()))
+                .collect(Collectors.joining("\n\n---\n\n"));
+
+        log.debug("Extracting metrics for {}/{}/{} using {} chunks via {}",
+                ticker, year, quarter, chunks.size(), provider);
+
+        FinancialMetricsDto dto = client.prompt()
+                .system(s -> s.text(systemPromptResource))
+                .user(u -> u.text("""
+                        Company: {ticker}
+                        Fiscal year: {year}
+                        Quarter: {quarter}
+
+                        Report excerpts:
+                        {context}
+                        """)
+                        .param("ticker", ticker)
+                        .param("year", String.valueOf(year))
+                        .param("quarter", quarter)
+                        .param("context", context))
+                .call()
+                .entity(FinancialMetricsDto.class);
+
+        log.debug("Extracted: revenue={}, netIncome={}, eps={}",
+                dto.getRevenue(), dto.getNetIncome(), dto.getEps());
+
+        return new FinancialMetrics(
+                ticker, year, quarter,
+                dto.getRevenue(),
+                dto.getNetIncome(),
+                dto.getEps(),
+                dto.getOperatingCashFlow(),
+                dto.getDebtToEquity());
+    }
+}

--- a/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/infrastructure/adapter/out/persistence/FinancialMetricsEntity.java
+++ b/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/infrastructure/adapter/out/persistence/FinancialMetricsEntity.java
@@ -1,0 +1,42 @@
+package com.aiarchitect.rag.report.infrastructure.adapter.out.persistence;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * JPA entity for persisting extracted {@link com.aiarchitect.rag.report.domain.model.FinancialMetrics}.
+ *
+ * <p>Kept in the infrastructure layer — the domain record has no JPA annotations.
+ * Mapping to/from the domain record is done in {@link ReportRepositoryAdapter}.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "financial_metrics",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"ticker", "year", "quarter"}))
+public class FinancialMetricsEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String ticker;
+
+    @Column(nullable = false)
+    private int year;
+
+    @Column(nullable = false)
+    private String quarter;
+
+    private Double revenue;
+    private Double netIncome;
+    private Double eps;
+    private Double operatingCashFlow;
+    private Double debtToEquity;
+}

--- a/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/infrastructure/adapter/out/persistence/FinancialMetricsJpaRepository.java
+++ b/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/infrastructure/adapter/out/persistence/FinancialMetricsJpaRepository.java
@@ -1,0 +1,16 @@
+package com.aiarchitect.rag.report.infrastructure.adapter.out.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Spring Data JPA repository for {@link FinancialMetricsEntity}.
+ */
+public interface FinancialMetricsJpaRepository extends JpaRepository<FinancialMetricsEntity, Long> {
+
+    Optional<FinancialMetricsEntity> findByTickerAndYearAndQuarter(String ticker, int year, String quarter);
+
+    List<FinancialMetricsEntity> findAllByTickerOrderByYearAscQuarterAsc(String ticker);
+}

--- a/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/infrastructure/adapter/out/persistence/ReportRepositoryAdapter.java
+++ b/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/infrastructure/adapter/out/persistence/ReportRepositoryAdapter.java
@@ -1,0 +1,84 @@
+package com.aiarchitect.rag.report.infrastructure.adapter.out.persistence;
+
+import com.aiarchitect.rag.report.domain.model.FinancialMetrics;
+import com.aiarchitect.rag.report.domain.port.out.ReportRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Outbound adapter: persists {@link FinancialMetrics} via Spring Data JPA.
+ *
+ * <p>Upsert logic: if a record for the same (ticker, year, quarter) already exists,
+ * its metric fields are updated in place; otherwise a new row is inserted.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReportRepositoryAdapter implements ReportRepositoryPort {
+
+    private final FinancialMetricsJpaRepository jpaRepository;
+
+    @Override
+    public FinancialMetrics save(FinancialMetrics metrics) {
+        // Upsert: reuse existing id if record already exists
+        FinancialMetricsEntity entity = jpaRepository
+                .findByTickerAndYearAndQuarter(metrics.ticker(), metrics.year(), metrics.quarter())
+                .map(existing -> {
+                    existing.setRevenue(metrics.revenue());
+                    existing.setNetIncome(metrics.netIncome());
+                    existing.setEps(metrics.eps());
+                    existing.setOperatingCashFlow(metrics.operatingCashFlow());
+                    existing.setDebtToEquity(metrics.debtToEquity());
+                    return existing;
+                })
+                .orElseGet(() -> toEntity(metrics));
+
+        FinancialMetricsEntity saved = jpaRepository.save(entity);
+        log.debug("Persisted FinancialMetrics id={} for {}/{}/{}",
+                saved.getId(), saved.getTicker(), saved.getYear(), saved.getQuarter());
+        return toDomain(saved);
+    }
+
+    @Override
+    public Optional<FinancialMetrics> findByTickerAndYearAndQuarter(String ticker, int year, String quarter) {
+        return jpaRepository.findByTickerAndYearAndQuarter(ticker, year, quarter)
+                .map(this::toDomain);
+    }
+
+    @Override
+    public List<FinancialMetrics> findAllByTicker(String ticker) {
+        return jpaRepository.findAllByTickerOrderByYearAscQuarterAsc(ticker)
+                .stream()
+                .map(this::toDomain)
+                .toList();
+    }
+
+    private FinancialMetrics toDomain(FinancialMetricsEntity entity) {
+        return new FinancialMetrics(
+                entity.getTicker(),
+                entity.getYear(),
+                entity.getQuarter(),
+                entity.getRevenue(),
+                entity.getNetIncome(),
+                entity.getEps(),
+                entity.getOperatingCashFlow(),
+                entity.getDebtToEquity());
+    }
+
+    private FinancialMetricsEntity toEntity(FinancialMetrics metrics) {
+        return FinancialMetricsEntity.builder()
+                .ticker(metrics.ticker())
+                .year(metrics.year())
+                .quarter(metrics.quarter())
+                .revenue(metrics.revenue())
+                .netIncome(metrics.netIncome())
+                .eps(metrics.eps())
+                .operatingCashFlow(metrics.operatingCashFlow())
+                .debtToEquity(metrics.debtToEquity())
+                .build();
+    }
+}

--- a/ai-architect/rag-report-analyzer/backend/src/main/resources/prompts/metrics-extraction.st
+++ b/ai-architect/rag-report-analyzer/backend/src/main/resources/prompts/metrics-extraction.st
@@ -1,0 +1,10 @@
+You are a financial data extraction assistant. Extract key financial metrics from the provided report excerpts and return them as a structured JSON object.
+
+Extraction rules:
+- Extract ONLY values explicitly stated in the provided excerpts. Do not infer, calculate, or use prior knowledge.
+- All monetary values must be in millions USD. Convert if needed (e.g. "$130.5 billion" → 130500.0).
+- Use null for any metric not found or not clearly stated in the excerpts.
+- For EPS, use the diluted earnings per share figure if both basic and diluted are present.
+- For debt-to-equity, use total debt divided by total stockholders' equity if both are given.
+
+Return only the JSON object — no explanation, no markdown, no additional text.

--- a/ai-architect/rag-report-analyzer/backend/src/test/java/com/aiarchitect/rag/report/service/MetricsExtractionServiceTest.java
+++ b/ai-architect/rag-report-analyzer/backend/src/test/java/com/aiarchitect/rag/report/service/MetricsExtractionServiceTest.java
@@ -1,0 +1,133 @@
+package com.aiarchitect.rag.report.service;
+
+import com.aiarchitect.rag.report.domain.model.FinancialMetrics;
+import com.aiarchitect.rag.report.domain.model.graph.MetricsGraph;
+import com.aiarchitect.rag.report.domain.port.out.DocumentStorePort;
+import com.aiarchitect.rag.report.domain.port.out.MetricsExtractionPort;
+import com.aiarchitect.rag.report.domain.port.out.ReportRepositoryPort;
+import com.aiarchitect.rag.report.domain.service.MetricsExtractionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.document.Document;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit test for {@link MetricsExtractionService}.
+ *
+ * <p>Verifies the orchestration: metadata filter is forwarded to the store,
+ * the extraction port receives the retrieved chunks, and the result is persisted.
+ */
+@DisplayName("MetricsExtractionService — orchestration")
+class MetricsExtractionServiceTest {
+
+    private DocumentStorePort documentStorePort;
+    private MetricsExtractionPort metricsExtractionPort;
+    private ReportRepositoryPort reportRepositoryPort;
+    private MetricsExtractionService service;
+
+    @BeforeEach
+    void setUp() {
+        documentStorePort = mock(DocumentStorePort.class);
+        metricsExtractionPort = mock(MetricsExtractionPort.class);
+        reportRepositoryPort = mock(ReportRepositoryPort.class);
+        service = new MetricsExtractionService(documentStorePort, metricsExtractionPort, reportRepositoryPort);
+    }
+
+    @Test
+    @DisplayName("extractAndSave: searches with financial keyword query + ticker/year filter")
+    void searchUsesFinancialKeywordQueryWithFilter() {
+        FinancialMetrics stub = metrics("NVDA", 2025, "Annual", 130497.0, 72880.0);
+        when(documentStorePort.similaritySearch(anyString(), anyInt(), anyMap())).thenReturn(List.of());
+        when(metricsExtractionPort.extract(any(), anyInt(), any(), anyList())).thenReturn(stub);
+        when(reportRepositoryPort.save(any())).thenReturn(stub);
+
+        service.extractAndSave("NVDA", 2025, "Annual");
+
+        verify(documentStorePort).similaritySearch(
+                eq(MetricsExtractionService.METRICS_QUERY),
+                eq(MetricsExtractionService.METRICS_TOP_K),
+                eq(Map.of("ticker", "NVDA", "year", 2025)));
+    }
+
+    @Test
+    @DisplayName("extractAndSave: extracted metrics are persisted and returned")
+    void extractedMetricsArePersistedAndReturned() {
+        Document chunk = new Document("Revenue was $130B.", Map.of("ticker", "NVDA", "year", 2025));
+        FinancialMetrics extracted = metrics("NVDA", 2025, "Annual", 130497.0, 72880.0);
+        FinancialMetrics saved = metrics("NVDA", 2025, "Annual", 130497.0, 72880.0);
+
+        when(documentStorePort.similaritySearch(anyString(), anyInt(), anyMap()))
+                .thenReturn(List.of(chunk));
+        when(metricsExtractionPort.extract("NVDA", 2025, "Annual", List.of(chunk)))
+                .thenReturn(extracted);
+        when(reportRepositoryPort.save(extracted)).thenReturn(saved);
+
+        FinancialMetrics result = service.extractAndSave("NVDA", 2025, "Annual");
+
+        assertThat(result.revenue()).isEqualTo(130497.0);
+        assertThat(result.netIncome()).isEqualTo(72880.0);
+        verify(reportRepositoryPort).save(extracted);
+    }
+
+    @Test
+    @DisplayName("extractAndSave: revenue is non-null after extraction")
+    void revenueIsNonNull() {
+        FinancialMetrics metricsWithRevenue = metrics("AAPL", 2024, "Q4", 94930.0, 14736.0);
+        when(documentStorePort.similaritySearch(anyString(), anyInt(), anyMap())).thenReturn(List.of());
+        when(metricsExtractionPort.extract(any(), anyInt(), any(), anyList())).thenReturn(metricsWithRevenue);
+        when(reportRepositoryPort.save(any())).thenReturn(metricsWithRevenue);
+
+        FinancialMetrics result = service.extractAndSave("AAPL", 2024, "Q4");
+
+        assertThat(result.revenue()).isNotNull().isPositive();
+    }
+
+    @Test
+    @DisplayName("getGraph: company + report + metric nodes are built from stored data")
+    void graphContainsCompanyReportAndMetricNodes() {
+        FinancialMetrics m = metrics("NVDA", 2025, "Annual", 130497.0, 72880.0);
+        when(reportRepositoryPort.findAllByTicker("NVDA")).thenReturn(List.of(m));
+
+        MetricsGraph graph = service.getGraph("NVDA");
+
+        assertThat(graph.nodes()).extracting("type")
+                .contains("company", "report", "metric");
+        assertThat(graph.edges()).extracting("label")
+                .contains("HAS_REPORT", "HAS_METRIC");
+
+        // Company node
+        assertThat(graph.nodes()).anyMatch(n -> n.id().equals("NVDA") && n.type().equals("company"));
+        // Report node
+        assertThat(graph.nodes()).anyMatch(n -> n.id().equals("NVDA-2025-Annual") && n.type().equals("report"));
+        // Metric nodes for non-null values (revenue + netIncome both set)
+        assertThat(graph.nodes()).anyMatch(n -> n.id().contains("revenue") && n.type().equals("metric"));
+    }
+
+    @Test
+    @DisplayName("getMetrics: delegates to repository")
+    void getMetricsDelegatesToRepository() {
+        FinancialMetrics m = metrics("NVDA", 2025, "Annual", 130497.0, null);
+        when(reportRepositoryPort.findByTickerAndYearAndQuarter("NVDA", 2025, "Annual"))
+                .thenReturn(Optional.of(m));
+
+        Optional<FinancialMetrics> result = service.getMetrics("NVDA", 2025, "Annual");
+
+        assertThat(result).isPresent();
+        assertThat(result.get().ticker()).isEqualTo("NVDA");
+    }
+
+    // ---- helpers ----
+
+    private static FinancialMetrics metrics(String ticker, int year, String quarter,
+                                             Double revenue, Double netIncome) {
+        return new FinancialMetrics(ticker, year, quarter, revenue, netIncome, null, null, null);
+    }
+}


### PR DESCRIPTION
## Summary

- **`FinancialMetrics`** — pure domain record: ticker, year, quarter, revenue, netIncome, eps, operatingCashFlow, debtToEquity (millions USD)
- **`MetricsExtractionService`** — retrieves top-10 chunks with broad financial keyword query + ticker/year filter → calls `MetricsExtractionPort` → persists via `ReportRepositoryPort`
- **`SpringAiMetricsExtractionAdapter`** — uses `ChatClient.call().entity(FinancialMetricsDto.class)` for LLM structured output; `FinancialMetricsDto` kept in infra layer (no Jackson in domain)
- **`ReportRepositoryAdapter`** — upsert by (ticker, year, quarter) via Spring Data JPA + H2
- **`MetricsGraph`** — D3-compatible graph model: Company → Report → Metric nodes + edges
- **`MetricsController`**:
  - `POST /api/v1/metrics/extract?ticker=NVDA&year=2025&quarter=Annual`
  - `GET /api/v1/metrics/{ticker}/{year}/{quarter}` → 404 if not yet extracted
  - `GET /api/v1/metrics/graph/{ticker}` → D3 nodes + edges
- **`prompts/metrics-extraction.st`** — extraction rules: null for missing values, unit normalization (billions → millions)
- **17 tests total, all green** (5 ArchUnit + 3 vector store + 4 Q&A + 5 metrics)

## What this phase demonstrates

- **Structured output**: `ChatClient.call().entity()` injects JSON schema into prompt and parses the response — no manual parsing
- **DTO isolation**: `FinancialMetricsDto` in infra layer keeps Jackson annotations out of the domain; adapter maps DTO → domain record
- **Upsert pattern**: re-extraction overwrites existing metrics for same period without duplicating rows
- **D3 graph model**: how to build a typed graph from relational data for frontend visualization

## Test plan
- [ ] CI passes
- [ ] `POST /api/v1/metrics/extract?ticker=NVDA&year=2025&quarter=Annual` after ingestion → non-null revenue
- [ ] `GET /api/v1/metrics/NVDA/2025/Annual` → same result
- [ ] `GET /api/v1/metrics/graph/NVDA` → nodes include `"company"`, `"report"`, `"metric"` types

🤖 Generated with [Claude Code](https://claude.com/claude-code)