### PR TITLE
refact #2(rag-financial-report): Phase 8 — TypeScript + Tailwind + TanStack Query + React Hook Form

### DIFF
--- a/ai-architect/rag-report-analyzer/frontend/package-lock.json
+++ b/ai-architect/rag-report-analyzer/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "d3": "^7.9.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-hook-form": "^7.71.2",
         "react-scripts": "5.0.1",
         "recharts": "^2.12.0",
         "tailwindcss": "^3.4.0",
@@ -17388,6 +17389,22 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.1.0.tgz",
       "integrity": "sha512-SN/U6Ytxf1QGkw/9ve5Y+NxBbZM6Ht95tuXNMKs8EJyFa/Vy/+Co3stop3KBHARfn/giv+Lj1uUnTfOJ3moFEQ==",
       "license": "MIT"
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.71.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.2.tgz",
+      "integrity": "sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/ai-architect/rag-report-analyzer/frontend/package.json
+++ b/ai-architect/rag-report-analyzer/frontend/package.json
@@ -14,6 +14,7 @@
     "d3": "^7.9.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.71.2",
     "react-scripts": "5.0.1",
     "recharts": "^2.12.0",
     "tailwindcss": "^3.4.0",

--- a/ai-architect/rag-report-analyzer/frontend/src/components/KnowledgeGraph.tsx
+++ b/ai-architect/rag-report-analyzer/frontend/src/components/KnowledgeGraph.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
 import * as d3 from 'd3';
 import { useQuery } from '@tanstack/react-query';
 import { getMetricsGraph } from '../services/ApiService';
@@ -13,27 +14,21 @@ const NODE_RADIUS: Record<GraphNode['type'], number> = { Company: 22, Report: 16
 
 const INPUT = 'px-3 py-1.5 border border-slate-300 rounded-md text-sm w-28 outline-none focus:border-indigo-500 transition-colors';
 
+interface GraphFormValues { ticker: string; }
+
 export default function KnowledgeGraph() {
-  const [ticker, setTicker] = useState('NVDA');
+  const { register, getValues } = useForm<GraphFormValues>({ defaultValues: { ticker: 'NVDA' } });
   const [info, setInfo] = useState<GraphNode | null>(null);
   const svgRef = useRef<SVGSVGElement>(null);
   const simRef = useRef<d3.Simulation<GraphNode, GraphEdge> | null>(null);
 
   const graphQuery = useQuery({
-    queryKey: ['metrics-graph', ticker] as const,
-    queryFn: () => getMetricsGraph(ticker).then(r => r.data),
+    queryKey: ['metrics-graph', 'NVDA'] as const,
+    queryFn: () => getMetricsGraph(getValues('ticker')).then(r => r.data),
     enabled: false,
   });
 
-  useEffect(() => {
-    if (!graphQuery.data) return;
-    drawGraph(graphQuery.data.nodes, graphQuery.data.edges);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [graphQuery.data]);
-
-  useEffect(() => () => { simRef.current?.stop(); }, []);
-
-  const drawGraph = (nodes: GraphNode[], edges: GraphEdge[]) => {
+  const drawGraph = useCallback((nodes: GraphNode[], edges: GraphEdge[]) => {
     if (!svgRef.current) return;
     simRef.current?.stop();
 
@@ -96,7 +91,14 @@ export default function KnowledgeGraph() {
       node.attr('cx', d => d.x ?? 0).attr('cy', d => d.y ?? 0);
       nodeLabel.attr('x', d => d.x ?? 0).attr('y', d => d.y ?? 0);
     });
-  };
+  }, [setInfo]);
+
+  useEffect(() => {
+    if (!graphQuery.data) return;
+    drawGraph(graphQuery.data.nodes, graphQuery.data.edges);
+  }, [graphQuery.data, drawGraph]);
+
+  useEffect(() => () => { simRef.current?.stop(); }, []);
 
   const error = graphQuery.error
     ? ((graphQuery.error as { response?: { status?: number } }).response?.status === 404
@@ -115,9 +117,14 @@ export default function KnowledgeGraph() {
       <div className="flex gap-3 flex-wrap items-end mb-4">
         <label className="text-xs font-medium text-slate-500 flex flex-col gap-1">
           Ticker
-          <input type="text" value={ticker} className={INPUT} onChange={e => setTicker(e.target.value.toUpperCase())} />
+          <input
+            type="text"
+            className={INPUT}
+            {...register('ticker', { required: true, setValueAs: (v: string) => v.toUpperCase() })}
+          />
         </label>
         <button
+          type="button"
           onClick={() => graphQuery.refetch()}
           disabled={graphQuery.isFetching}
           className="px-5 py-1.5 bg-indigo-600 text-white rounded-md text-sm font-medium transition-colors hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"

--- a/ai-architect/rag-report-analyzer/frontend/src/components/MetricsDashboard.tsx
+++ b/ai-architect/rag-report-analyzer/frontend/src/components/MetricsDashboard.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useMemo } from 'react';
+import React, { useMemo } from 'react';
+import { useForm } from 'react-hook-form';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
@@ -29,21 +30,30 @@ function MetricsCard({ label, value, unit }: MetricsCardProps) {
   );
 }
 
+interface MetricsFormValues { ticker: string; year: number; quarter: Quarter; }
+
 export default function MetricsDashboard() {
-  const [ticker, setTicker] = useState('NVDA');
-  const [year, setYear] = useState(2025);
-  const [quarter, setQuarter] = useState<Quarter>('Annual');
+  const { register, getValues } = useForm<MetricsFormValues>({
+    defaultValues: { ticker: 'NVDA', year: 2025, quarter: 'Annual' },
+  });
   const queryClient = useQueryClient();
 
   const metricsQuery = useQuery({
-    queryKey: ['metrics', ticker, year, quarter] as const,
-    queryFn: () => getMetrics(ticker, year, quarter).then(r => r.data),
+    queryKey: ['metrics', 'NVDA', 2025, 'Annual'] as const,
+    queryFn: () => {
+      const { ticker, year, quarter } = getValues();
+      return getMetrics(ticker, year, quarter).then(r => r.data);
+    },
     enabled: false,
   });
 
   const extractMutation = useMutation({
-    mutationFn: () => extractMetrics(ticker, year, quarter).then(r => r.data),
+    mutationFn: () => {
+      const { ticker, year, quarter } = getValues();
+      return extractMetrics(ticker, year, quarter).then(r => r.data);
+    },
     onSuccess: data => {
+      const { ticker, year, quarter } = getValues();
       queryClient.setQueryData(['metrics', ticker, year, quarter], data);
     },
   });
@@ -76,15 +86,23 @@ export default function MetricsDashboard() {
         <div className="flex gap-3 flex-wrap items-end mb-4">
           <label className="text-xs font-medium text-slate-500 flex flex-col gap-1">
             Ticker
-            <input type="text" value={ticker} className={INPUT + ' w-28'} onChange={e => setTicker(e.target.value.toUpperCase())} />
+            <input
+              type="text"
+              className={INPUT + ' w-28'}
+              {...register('ticker', { required: true, setValueAs: (v: string) => v.toUpperCase() })}
+            />
           </label>
           <label className="text-xs font-medium text-slate-500 flex flex-col gap-1">
             Year
-            <input type="number" value={year} className={INPUT + ' w-24'} onChange={e => setYear(Number(e.target.value))} />
+            <input
+              type="number"
+              className={INPUT + ' w-24'}
+              {...register('year', { required: true, valueAsNumber: true })}
+            />
           </label>
           <label className="text-xs font-medium text-slate-500 flex flex-col gap-1">
             Quarter
-            <select value={quarter} className={INPUT + ' w-28'} onChange={e => setQuarter(e.target.value as Quarter)}>
+            <select className={INPUT + ' w-28'} {...register('quarter')}>
               <option value="Annual">Annual</option>
               <option value="Q1">Q1</option>
               <option value="Q2">Q2</option>
@@ -93,6 +111,7 @@ export default function MetricsDashboard() {
             </select>
           </label>
           <button
+            type="button"
             onClick={() => metricsQuery.refetch()}
             disabled={isLoading}
             className="px-5 py-1.5 bg-indigo-600 text-white rounded-md text-sm font-medium transition-colors hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
@@ -100,6 +119,7 @@ export default function MetricsDashboard() {
             {isLoading ? 'Loading…' : 'Load Metrics'}
           </button>
           <button
+            type="button"
             onClick={() => extractMutation.mutate()}
             disabled={isExtracting}
             className="px-5 py-1.5 bg-slate-200 text-slate-700 rounded-md text-sm font-medium transition-colors hover:bg-slate-300 disabled:opacity-50 disabled:cursor-not-allowed"

--- a/ai-architect/rag-report-analyzer/frontend/src/components/PredictionPanel.tsx
+++ b/ai-architect/rag-report-analyzer/frontend/src/components/PredictionPanel.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React from 'react';
+import { useForm } from 'react-hook-form';
 import { useMutation } from '@tanstack/react-query';
 import { predict } from '../services/ApiService';
 import type { FinancialOutlook, PredictionMode } from '../types/api';
@@ -11,15 +12,20 @@ const MODES: Array<{ value: PredictionMode; label: string; desc: string }> = [
 
 const INPUT = 'px-3 py-1.5 border border-slate-300 rounded-md text-sm w-28 outline-none focus:border-indigo-500 transition-colors';
 
+interface PredictionFormValues { ticker: string; mode: PredictionMode; }
+
 export default function PredictionPanel() {
-  const [ticker, setTicker] = useState('NVDA');
-  const [mode, setMode] = useState<PredictionMode>('NARRATIVE_PREDICTION');
+  const { register, handleSubmit } = useForm<PredictionFormValues>({
+    defaultValues: { ticker: 'NVDA', mode: 'NARRATIVE_PREDICTION' },
+  });
 
   const mutation = useMutation({
-    mutationFn: () => predict(ticker, mode).then(r => r.data),
+    mutationFn: (values: PredictionFormValues) => predict(values.ticker, values.mode).then(r => r.data),
   });
 
   const outlook: FinancialOutlook | undefined = mutation.data;
+
+  const onSubmit = handleSubmit(data => mutation.mutate(data));
 
   return (
     <div>
@@ -30,55 +36,55 @@ export default function PredictionPanel() {
           Requires at least one period of extracted metrics.
         </p>
 
-        <div className="flex gap-3 flex-wrap items-end mb-4">
-          <label className="text-xs font-medium text-slate-500 flex flex-col gap-1">
-            Ticker
-            <input type="text" value={ticker} className={INPUT} onChange={e => setTicker(e.target.value.toUpperCase())} />
-          </label>
-        </div>
-
-        <div className="mb-4">
-          <div className="text-xs font-medium text-slate-500 mb-2">Prediction Mode</div>
-          <div className="flex gap-4 flex-wrap">
-            {MODES.map(m => (
-              <label key={m.value} className="flex items-center gap-1.5 cursor-pointer text-sm text-slate-700">
-                <input
-                  type="radio"
-                  name="mode"
-                  value={m.value}
-                  checked={mode === m.value}
-                  onChange={() => setMode(m.value)}
-                />
-                <span>
-                  <strong>{m.label}</strong>
-                  <span className="text-[0.75rem] text-slate-400 ml-1">— {m.desc}</span>
-                </span>
-              </label>
-            ))}
+        <form onSubmit={onSubmit}>
+          <div className="flex gap-3 flex-wrap items-end mb-4">
+            <label className="text-xs font-medium text-slate-500 flex flex-col gap-1">
+              Ticker
+              <input
+                type="text"
+                className={INPUT}
+                {...register('ticker', { required: true, setValueAs: (v: string) => v.toUpperCase() })}
+              />
+            </label>
           </div>
-        </div>
 
-        <button
-          onClick={() => mutation.mutate()}
-          disabled={mutation.isPending}
-          className="px-5 py-1.5 bg-indigo-600 text-white rounded-md text-sm font-medium transition-colors hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {mutation.isPending ? 'Predicting…' : 'Generate Outlook'}
-        </button>
-        {mutation.isError && (
-          <p className="text-red-600 text-sm mt-2">
-            {(mutation.error as Error & { response?: { status?: number; data?: { message?: string } } }).response?.status === 400
-              ? 'No metrics stored for this ticker. Extract metrics first.'
-              : ((mutation.error as Error & { response?: { data?: { message?: string } } }).response?.data?.message
-                  ?? (mutation.error as Error).message)}
-          </p>
-        )}
+          <div className="mb-4">
+            <div className="text-xs font-medium text-slate-500 mb-2">Prediction Mode</div>
+            <div className="flex gap-4 flex-wrap">
+              {MODES.map(m => (
+                <label key={m.value} className="flex items-center gap-1.5 cursor-pointer text-sm text-slate-700">
+                  <input type="radio" value={m.value} {...register('mode', { required: true })} />
+                  <span>
+                    <strong>{m.label}</strong>
+                    <span className="text-[0.75rem] text-slate-400 ml-1">— {m.desc}</span>
+                  </span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            disabled={mutation.isPending}
+            className="px-5 py-1.5 bg-indigo-600 text-white rounded-md text-sm font-medium transition-colors hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {mutation.isPending ? 'Predicting…' : 'Generate Outlook'}
+          </button>
+          {mutation.isError && (
+            <p className="text-red-600 text-sm mt-2">
+              {(mutation.error as Error & { response?: { status?: number; data?: { message?: string } } }).response?.status === 400
+                ? 'No metrics stored for this ticker. Extract metrics first.'
+                : ((mutation.error as Error & { response?: { data?: { message?: string } } }).response?.data?.message
+                    ?? (mutation.error as Error).message)}
+            </p>
+          )}
+        </form>
       </div>
 
       {outlook && (
         <div className="bg-white rounded-xl p-6 shadow-sm mb-6">
           <h3 className="text-[0.95rem] font-medium mb-4 text-slate-700 flex items-center gap-2">
-            {ticker} Financial Outlook
+            Financial Outlook
             <span className="inline-block bg-violet-100 text-violet-800 text-xs px-2 py-0.5 rounded font-medium">
               {outlook.methodology}
             </span>

--- a/ai-architect/rag-report-analyzer/frontend/src/components/QaInterface.tsx
+++ b/ai-architect/rag-report-analyzer/frontend/src/components/QaInterface.tsx
@@ -1,49 +1,68 @@
-import React, { useState } from 'react';
+import React from 'react';
+import { useForm } from 'react-hook-form';
 import { useMutation } from '@tanstack/react-query';
 import { askQuestion } from '../services/ApiService';
 import type { QaResponse } from '../types/api';
 
 const INPUT = 'px-3 py-1.5 border border-slate-300 rounded-md text-sm outline-none focus:border-indigo-500 transition-colors';
 
+interface QaFormValues {
+  question: string;
+  ticker: string;
+  year: number;
+}
+
 export default function QaInterface() {
-  const [question, setQuestion] = useState('');
-  const [ticker, setTicker] = useState('NVDA');
-  const [year, setYear] = useState(2025);
+  const { register, handleSubmit, watch } = useForm<QaFormValues>({
+    defaultValues: { ticker: 'NVDA', year: 2025, question: '' },
+  });
+
+  const question = watch('question');
 
   const mutation = useMutation({
-    mutationFn: () => askQuestion(question, ticker, year).then(r => r.data),
+    mutationFn: (values: QaFormValues) =>
+      askQuestion(values.question, values.ticker, values.year).then(r => r.data),
   });
 
   const result: QaResponse | undefined = mutation.data;
+
+  const onSubmit = handleSubmit(data => mutation.mutate(data));
 
   return (
     <div>
       <div className="bg-white rounded-xl p-6 shadow-sm mb-6">
         <h2 className="text-lg font-semibold mb-4 text-slate-800">Financial Q&amp;A</h2>
-        <form onSubmit={e => { e.preventDefault(); if (question.trim()) mutation.mutate(); }}>
+        <form onSubmit={onSubmit}>
           <div className="flex gap-3 flex-wrap items-end mb-4">
             <label className="text-xs font-medium text-slate-500 flex flex-col gap-1">
               Ticker
-              <input type="text" value={ticker} className={INPUT + ' w-28'} onChange={e => setTicker(e.target.value.toUpperCase())} />
+              <input
+                type="text"
+                className={INPUT + ' w-28'}
+                {...register('ticker', { required: true, setValueAs: (v: string) => v.toUpperCase() })}
+              />
             </label>
             <label className="text-xs font-medium text-slate-500 flex flex-col gap-1">
               Fiscal Year
-              <input type="number" value={year} className={INPUT + ' w-24'} onChange={e => setYear(Number(e.target.value))} />
+              <input
+                type="number"
+                className={INPUT + ' w-24'}
+                {...register('year', { required: true, valueAsNumber: true })}
+              />
             </label>
           </div>
           <label className="text-xs font-medium text-slate-500 flex flex-col gap-1 mb-3">
             Question
             <textarea
               rows={3}
-              value={question}
-              onChange={e => setQuestion(e.target.value)}
               placeholder="What was the total revenue for fiscal year 2025?"
               className="mt-1 w-full px-3 py-2 border border-slate-300 rounded-md text-sm resize-y outline-none focus:border-indigo-500 transition-colors font-sans"
+              {...register('question', { required: true })}
             />
           </label>
           <button
             type="submit"
-            disabled={mutation.isPending || !question.trim()}
+            disabled={mutation.isPending || !question?.trim()}
             className="px-5 py-1.5 bg-indigo-600 text-white rounded-md text-sm font-medium transition-colors hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {mutation.isPending ? 'Asking…' : 'Ask'}

--- a/ai-architect/rag-report-analyzer/frontend/src/components/ReportUploader.tsx
+++ b/ai-architect/rag-report-analyzer/frontend/src/components/ReportUploader.tsx
@@ -1,22 +1,37 @@
 import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
 import { useMutation } from '@tanstack/react-query';
 import { ingestReport } from '../services/ApiService';
 import type { Quarter } from '../types/api';
 
+interface UploadFormValues {
+  file: FileList;
+  ticker: string;
+  year: number;
+  quarter: Quarter;
+}
+
 const INPUT = 'px-3 py-1.5 border border-slate-300 rounded-md text-sm outline-none focus:border-indigo-500 transition-colors';
 
 export default function ReportUploader() {
-  const [file, setFile] = useState<File | null>(null);
-  const [ticker, setTicker] = useState('NVDA');
-  const [year, setYear] = useState(2025);
-  const [quarter, setQuarter] = useState<Quarter>('Annual');
   const [progress, setProgress] = useState(0);
+  const { register, handleSubmit, watch } = useForm<UploadFormValues>({
+    defaultValues: { ticker: 'NVDA', year: 2025, quarter: 'Annual' },
+  });
+
+  const fileList = watch('file');
+  const hasFile = fileList && fileList.length > 0;
 
   const mutation = useMutation({
-    mutationFn: () => {
-      if (!file) throw new Error('No file selected');
-      return ingestReport(file, ticker, year, quarter, setProgress);
-    },
+    mutationFn: (values: UploadFormValues) =>
+      ingestReport(values.file[0], values.ticker, values.year, values.quarter, setProgress),
+    onSuccess: () => setProgress(100),
+  });
+
+  const onSubmit = handleSubmit(data => {
+    setProgress(0);
+    mutation.reset();
+    mutation.mutate(data);
   });
 
   return (
@@ -25,7 +40,7 @@ export default function ReportUploader() {
       <p className="text-sm text-slate-500 mb-4">
         Ingests a PDF (10-K / 10-Q), chunks it, embeds the chunks, and stores them in the vector store.
       </p>
-      <form onSubmit={e => { e.preventDefault(); mutation.mutate(); }}>
+      <form onSubmit={onSubmit}>
         <div className="flex gap-3 flex-wrap items-end mb-4">
           <label className="text-xs font-medium text-slate-500 flex flex-col gap-1">
             PDF File
@@ -33,33 +48,31 @@ export default function ReportUploader() {
               type="file"
               accept=".pdf"
               className={INPUT + ' w-auto'}
-              onChange={e => { setFile(e.target.files?.[0] ?? null); mutation.reset(); }}
+              {...register('file', { required: true })}
             />
           </label>
           <label className="text-xs font-medium text-slate-500 flex flex-col gap-1">
             Ticker
             <input
               type="text"
-              value={ticker}
               className={INPUT + ' w-28'}
-              onChange={e => setTicker(e.target.value.toUpperCase())}
               placeholder="NVDA"
+              {...register('ticker', { required: true, setValueAs: (v: string) => v.toUpperCase() })}
             />
           </label>
           <label className="text-xs font-medium text-slate-500 flex flex-col gap-1">
             Fiscal Year
             <input
               type="number"
-              value={year}
               className={INPUT + ' w-24'}
-              onChange={e => setYear(Number(e.target.value))}
               min={2000}
               max={2100}
+              {...register('year', { required: true, valueAsNumber: true })}
             />
           </label>
           <label className="text-xs font-medium text-slate-500 flex flex-col gap-1">
             Quarter
-            <select value={quarter} className={INPUT + ' w-28'} onChange={e => setQuarter(e.target.value as Quarter)}>
+            <select className={INPUT + ' w-28'} {...register('quarter')}>
               <option value="Annual">Annual</option>
               <option value="Q1">Q1</option>
               <option value="Q2">Q2</option>
@@ -69,7 +82,7 @@ export default function ReportUploader() {
           </label>
           <button
             type="submit"
-            disabled={!file || mutation.isPending}
+            disabled={!hasFile || mutation.isPending}
             className="px-5 py-1.5 bg-indigo-600 text-white rounded-md text-sm font-medium transition-colors hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {mutation.isPending ? 'Uploading…' : 'Ingest Report'}
@@ -85,13 +98,14 @@ export default function ReportUploader() {
           </div>
         )}
         {mutation.isSuccess && (
-          <p className="text-emerald-600 text-sm mt-2">Report ingested successfully ({file?.name}).</p>
+          <p className="text-emerald-600 text-sm mt-2">
+            Report ingested successfully ({fileList?.[0]?.name}).
+          </p>
         )}
         {mutation.isError && (
           <p className="text-red-600 text-sm mt-2">
-            {(mutation.error as Error & { response?: { data?: { message?: string } } }).response?.data?.message
-              ?? (mutation.error as Error).message
-              ?? 'Upload failed.'}
+            {(mutation.error as Error & { response?: { data?: { message?: string } } })
+              .response?.data?.message ?? (mutation.error as Error).message ?? 'Upload failed.'}
           </p>
         )}
       </form>


### PR DESCRIPTION
## Summary
- Migrate all 5 frontend components from plain JS/CSS to TypeScript + Tailwind CSS v3
- Replace manual `useState` async patterns with TanStack Query v5 (`useQuery` + `useMutation`)
- Replace uncontrolled/controlled form inputs with `react-hook-form` (`useForm`, `register`, `handleSubmit`) across all components
- Eliminate `eslint-disable-next-line` in `KnowledgeGraph` by wrapping `drawGraph` in `useCallback`
- Add shared `src/types/api.ts` with all TypeScript interfaces; D3 types via `@types/d3`
- All 5 tests passing

## Test plan
- [ ] `npm test` → 5/5 pass
- [ ] Upload screen: file + ticker + year + quarter → Ingest Report
- [ ] Q&A screen: ticker/year/question form → Ask button
- [ ] Metrics screen: Load Metrics + Extract via LLM buttons
- [ ] Prediction screen: radio mode selector + Generate Outlook
- [ ] Knowledge Graph screen: Load Graph button + D3 drag/zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)