### PR TITLE
feat #2(rag-financial-report): Phase 11 — Full Observability (4 Layers)

### DIFF
--- a/ai-architect/rag-report-analyzer/backend/build.gradle.kts
+++ b/ai-architect/rag-report-analyzer/backend/build.gradle.kts
@@ -60,6 +60,13 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("io.micrometer:micrometer-registry-prometheus")
 
+    // Distributed tracing — Micrometer Tracing bridge + OTel OTLP exporter → Grafana Tempo
+    implementation("io.micrometer:micrometer-tracing-bridge-otel")
+    implementation("io.opentelemetry:opentelemetry-exporter-otlp")
+
+    // Centralised logging — Loki4j appender pushes JSON logs (with traceId/spanId) to Grafana Loki
+    implementation("com.github.loki4j:loki-logback-appender:1.5.2")
+
     // H2 for local dev
     runtimeOnly("com.h2database:h2")
 

--- a/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/infrastructure/adapter/out/ai/SpringAiMetricsExtractionAdapter.java
+++ b/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/infrastructure/adapter/out/ai/SpringAiMetricsExtractionAdapter.java
@@ -4,6 +4,8 @@ import com.aiarchitect.rag.report.domain.model.FinancialMetrics;
 import com.aiarchitect.rag.report.domain.model.LlmCallException;
 import com.aiarchitect.rag.report.domain.port.out.MetricsExtractionPort;
 import com.aiarchitect.rag.report.infrastructure.props.AiProviderProperties;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
@@ -41,6 +43,7 @@ public class SpringAiMetricsExtractionAdapter implements MetricsExtractionPort {
 
     private final Map<String, ChatClient> chatClientsByProvider;
     private final AiProviderProperties aiProviderProperties;
+    private final MeterRegistry meterRegistry;
 
     @Value("classpath:prompts/metrics-extraction.st")
     private Resource systemPromptResource;
@@ -69,22 +72,26 @@ public class SpringAiMetricsExtractionAdapter implements MetricsExtractionPort {
         log.debug("Extracting metrics for {}/{}/{} using {} chunks via {}",
                 ticker, year, quarter, chunks.size(), provider);
 
-        FinancialMetricsDto dto = client.prompt()
-                .system(s -> s.text(systemPromptResource))
-                .user(u -> u.text("""
-                        Company: {ticker}
-                        Fiscal year: {year}
-                        Quarter: {quarter}
+        FinancialMetricsDto dto = Timer.builder("llm.call.duration")
+                .tag("provider", provider)
+                .tag("operation", "metrics_extraction")
+                .register(meterRegistry)
+                .record(() -> client.prompt()
+                        .system(s -> s.text(systemPromptResource))
+                        .user(u -> u.text("""
+                                Company: {ticker}
+                                Fiscal year: {year}
+                                Quarter: {quarter}
 
-                        Report excerpts:
-                        {context}
-                        """)
-                        .param("ticker", ticker)
-                        .param("year", String.valueOf(year))
-                        .param("quarter", quarter)
-                        .param("context", context))
-                .call()
-                .entity(FinancialMetricsDto.class);
+                                Report excerpts:
+                                {context}
+                                """)
+                                .param("ticker", ticker)
+                                .param("year", String.valueOf(year))
+                                .param("quarter", quarter)
+                                .param("context", context))
+                        .call()
+                        .entity(FinancialMetricsDto.class));
 
         log.debug("Extracted: revenue={}, netIncome={}, eps={}",
                 dto.getRevenue(), dto.getNetIncome(), dto.getEps());

--- a/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/infrastructure/adapter/out/eval/LlmEvalJudgeAdapter.java
+++ b/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/infrastructure/adapter/out/eval/LlmEvalJudgeAdapter.java
@@ -4,6 +4,8 @@ import com.aiarchitect.rag.report.domain.model.LlmCallException;
 import com.aiarchitect.rag.report.domain.model.eval.EvalScores;
 import com.aiarchitect.rag.report.domain.port.out.EvalJudgePort;
 import com.aiarchitect.rag.report.infrastructure.props.AiProviderProperties;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
@@ -36,6 +38,7 @@ public class LlmEvalJudgeAdapter implements EvalJudgePort {
 
     private final Map<String, ChatClient> chatClientsByProvider;
     private final AiProviderProperties aiProviderProperties;
+    private final MeterRegistry meterRegistry;
 
     @Value("classpath:prompts/eval-judge.st")
     private Resource systemPromptResource;
@@ -69,27 +72,31 @@ public class LlmEvalJudgeAdapter implements EvalJudgePort {
         log.debug("Judging answer for question='{}' with {} context chunks via {}",
                 question, retrievedChunks.size(), provider);
 
-        EvalScoresDto dto = client.prompt()
-                .system(s -> s.text(systemPromptResource))
-                .user(u -> u.text("""
-                        Question: {question}
+        EvalScoresDto dto = Timer.builder("llm.call.duration")
+                .tag("provider", provider)
+                .tag("operation", "eval_judge")
+                .register(meterRegistry)
+                .record(() -> client.prompt()
+                        .system(s -> s.text(systemPromptResource))
+                        .user(u -> u.text("""
+                                Question: {question}
 
-                        Expected answer (ground truth):
-                        {expectedAnswer}
+                                Expected answer (ground truth):
+                                {expectedAnswer}
 
-                        Generated answer (RAG pipeline output):
-                        {generatedAnswer}
+                                Generated answer (RAG pipeline output):
+                                {generatedAnswer}
 
-                        Retrieved context ({chunkCount} chunks):
-                        {context}
-                        """)
-                        .param("question", question)
-                        .param("expectedAnswer", expectedAnswer)
-                        .param("generatedAnswer", generatedAnswer)
-                        .param("chunkCount", String.valueOf(retrievedChunks.size()))
-                        .param("context", context.isEmpty() ? "(no chunks retrieved)" : context))
-                .call()
-                .entity(EvalScoresDto.class);
+                                Retrieved context ({chunkCount} chunks):
+                                {context}
+                                """)
+                                .param("question", question)
+                                .param("expectedAnswer", expectedAnswer)
+                                .param("generatedAnswer", generatedAnswer)
+                                .param("chunkCount", String.valueOf(retrievedChunks.size()))
+                                .param("context", context.isEmpty() ? "(no chunks retrieved)" : context))
+                        .call()
+                        .entity(EvalScoresDto.class));
 
         double precision = safeScore(dto.getContextPrecision());
         double recall = safeScore(dto.getContextRecall());

--- a/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/infrastructure/adapter/out/vectorstore/ChromaVectorStoreAdapter.java
+++ b/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/infrastructure/adapter/out/vectorstore/ChromaVectorStoreAdapter.java
@@ -1,6 +1,8 @@
 package com.aiarchitect.rag.report.infrastructure.adapter.out.vectorstore;
 
 import com.aiarchitect.rag.report.domain.port.out.DocumentStorePort;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.document.Document;
@@ -27,8 +29,9 @@ import java.util.Map;
  *   <li>The filter is pushed to the database engine, reducing network transfer
  * </ul>
  *
- * <p>The domain code ({@link com.aiarchitect.rag.report.domain.port.out.DocumentStorePort})
- * is unchanged — this is the hexagonal architecture pay-off.
+ * <h3>Observability</h3>
+ * Records {@code vector.store.operation} timer tagged with {@code type=chroma} and
+ * {@code operation=store|search} for all operations.
  */
 @Slf4j
 @Component
@@ -37,19 +40,28 @@ import java.util.Map;
 public class ChromaVectorStoreAdapter implements DocumentStorePort {
 
     private final VectorStore vectorStore;
+    private final MeterRegistry meterRegistry;
 
     @Override
     public void store(List<Document> documents) {
         log.debug("Storing {} documents in ChromaDB", documents.size());
-        vectorStore.add(documents);
+        Timer.builder("vector.store.operation")
+                .tag("type", "chroma")
+                .tag("operation", "store")
+                .register(meterRegistry)
+                .record(() -> vectorStore.add(documents));
         log.debug("Stored {} documents", documents.size());
     }
 
     @Override
     public List<Document> similaritySearch(String query, int topK) {
         log.debug("ChromaDB similarity search: query='{}', topK={}", query, topK);
-        List<Document> results = vectorStore.similaritySearch(
-                SearchRequest.builder().query(query).topK(topK).build());
+        List<Document> results = Timer.builder("vector.store.operation")
+                .tag("type", "chroma")
+                .tag("operation", "search")
+                .register(meterRegistry)
+                .record(() -> vectorStore.similaritySearch(
+                        SearchRequest.builder().query(query).topK(topK).build()));
         log.debug("Found {} results", results.size());
         return results;
     }
@@ -76,7 +88,11 @@ public class ChromaVectorStoreAdapter implements DocumentStorePort {
                 ? SearchRequest.builder().query(query).topK(topK).filterExpression(filterExpression).build()
                 : SearchRequest.builder().query(query).topK(topK).build();
 
-        List<Document> results = vectorStore.similaritySearch(request);
+        List<Document> results = Timer.builder("vector.store.operation")
+                .tag("type", "chroma")
+                .tag("operation", "search_filtered")
+                .register(meterRegistry)
+                .record(() -> vectorStore.similaritySearch(request));
         log.debug("ChromaDB filtered to {} results for query='{}'", results.size(), query);
         return results;
     }

--- a/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/infrastructure/adapter/out/vectorstore/SimpleVectorStoreAdapter.java
+++ b/ai-architect/rag-report-analyzer/backend/src/main/java/com/aiarchitect/rag/report/infrastructure/adapter/out/vectorstore/SimpleVectorStoreAdapter.java
@@ -1,6 +1,8 @@
 package com.aiarchitect.rag.report.infrastructure.adapter.out.vectorstore;
 
 import com.aiarchitect.rag.report.domain.port.out.DocumentStorePort;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.document.Document;
@@ -26,19 +28,28 @@ import java.util.Map;
 public class SimpleVectorStoreAdapter implements DocumentStorePort {
 
     private final VectorStore vectorStore;
+    private final MeterRegistry meterRegistry;
 
     @Override
     public void store(List<Document> documents) {
         log.debug("Storing {} documents in vector store", documents.size());
-        vectorStore.add(documents);
+        Timer.builder("vector.store.operation")
+                .tag("type", "simple")
+                .tag("operation", "store")
+                .register(meterRegistry)
+                .record(() -> vectorStore.add(documents));
         log.debug("Stored {} documents", documents.size());
     }
 
     @Override
     public List<Document> similaritySearch(String query, int topK) {
         log.debug("Similarity search: query='{}', topK={}", query, topK);
-        List<Document> results = vectorStore.similaritySearch(
-                SearchRequest.builder().query(query).topK(topK).build());
+        List<Document> results = Timer.builder("vector.store.operation")
+                .tag("type", "simple")
+                .tag("operation", "search")
+                .register(meterRegistry)
+                .record(() -> vectorStore.similaritySearch(
+                        SearchRequest.builder().query(query).topK(topK).build()));
         log.debug("Found {} results for query='{}'", results.size(), query);
         return results;
     }
@@ -52,13 +63,19 @@ public class SimpleVectorStoreAdapter implements DocumentStorePort {
     @Override
     public List<Document> similaritySearch(String query, int topK, Map<String, Object> metadataFilter) {
         log.debug("Filtered search: query='{}', topK={}, filter={}", query, topK, metadataFilter);
-        List<Document> candidates = vectorStore.similaritySearch(
-                SearchRequest.builder().query(query).topK(topK * 3).build());
-        List<Document> results = candidates.stream()
-                .filter(doc -> metadataFilter.entrySet().stream()
-                        .allMatch(e -> e.getValue().equals(doc.getMetadata().get(e.getKey()))))
-                .limit(topK)
-                .toList();
+        List<Document> results = Timer.builder("vector.store.operation")
+                .tag("type", "simple")
+                .tag("operation", "search_filtered")
+                .register(meterRegistry)
+                .record(() -> {
+                    List<Document> candidates = vectorStore.similaritySearch(
+                            SearchRequest.builder().query(query).topK(topK * 3).build());
+                    return candidates.stream()
+                            .filter(doc -> metadataFilter.entrySet().stream()
+                                    .allMatch(e -> e.getValue().equals(doc.getMetadata().get(e.getKey()))))
+                            .limit(topK)
+                            .toList();
+                });
         log.debug("Filtered to {} results for query='{}'", results.size(), query);
         return results;
     }

--- a/ai-architect/rag-report-analyzer/backend/src/main/resources/application.yml
+++ b/ai-architect/rag-report-analyzer/backend/src/main/resources/application.yml
@@ -37,6 +37,21 @@ spring:
         options:
           model: nomic-embed-text
 
+    # Spring AI observations (Layer 4) — emits spans + metrics for ChatClient / VectorStore / Embedding
+    # Enabled automatically when Micrometer is on the classpath.
+    # Set include-input/include-output=true only if prompts are non-sensitive (PII risk).
+    chat:
+      client:
+        observations:
+          include-input: false
+          include-output: false
+    vectorstore:
+      observations:
+        include-query-response: false
+    embedding:
+      observations:
+        include-input: false
+
 server:
   port: 8080
 
@@ -80,9 +95,26 @@ management:
     export:
       prometheus:
         enabled: true
+    # Tag every metric with the service name — visible in Grafana as a label
+    tags:
+      application: ${spring.application.name}
   endpoint:
     health:
       show-details: when-authorized
+
+  # Distributed tracing (Layer 2) — Micrometer Tracing + OTel OTLP → Grafana Tempo
+  tracing:
+    sampling:
+      # 100 % in dev; override via TRACING_SAMPLING_PROBABILITY env var in prod (e.g. 0.1)
+      probability: ${TRACING_SAMPLING_PROBABILITY:1.0}
+  otlp:
+    tracing:
+      # OTLP gRPC endpoint — point to Grafana Tempo (default) or any OTel Collector
+      endpoint: ${OTLP_ENDPOINT:http://tempo:4317}
+
+# Bridge LOKI_URL env var to Spring property so logback-spring.xml can read it via springProperty
+loki:
+  url: ${LOKI_URL:http://loki:3100}
 
 logging:
   level:

--- a/ai-architect/rag-report-analyzer/backend/src/main/resources/logback-spring.xml
+++ b/ai-architect/rag-report-analyzer/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Logback config (Layer 3 — Centralised Logging).
+
+  Two appenders run in parallel:
+    CONSOLE — plain-text for local dev (pattern includes traceId/spanId injected by Micrometer Tracing)
+    LOKI    — JSON push to Grafana Loki; traceId/spanId in JSON fields enable cross-linking
+              to traces in Grafana Tempo ("jump to trace" from a log line).
+
+  LOKI_URL env var (default: http://loki:3100) is set by docker-compose under the
+  "observability" profile. When the Loki service is not running the appender silently
+  discards events — no impact on application behaviour.
+-->
+<configuration>
+    <springProperty scope="context" name="APP_NAME"   source="spring.application.name" defaultValue="rag-report-analyzer"/>
+    <springProperty scope="context" name="LOKI_URL"   source="loki.url"                defaultValue="http://loki:3100"/>
+
+    <!-- ── Console appender (local dev) ──────────────────────────────────── -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <!-- traceId / spanId are added to MDC automatically by Micrometer Tracing -->
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%X{traceId:-},%X{spanId:-}] %cyan(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- ── Loki appender (Grafana Loki, JSON format) ──────────────────────── -->
+    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>${LOKI_URL}/loki/api/v1/push</url>
+            <!-- Batch up to 1 s or 1 000 log lines, whichever comes first -->
+            <batchMaxItems>1000</batchMaxItems>
+            <batchTimeoutMs>1000</batchTimeoutMs>
+        </http>
+        <format>
+            <label>
+                <!-- Grafana stream selectors — low-cardinality fields only -->
+                <pattern>app=${APP_NAME},level=%level,logger=%logger{20}</pattern>
+            </label>
+            <message>
+                <!-- JSON layout: includes timestamp, level, logger, message, MDC (traceId/spanId) -->
+                <pattern>{"ts":"%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}","level":"%level","logger":"%logger{36}","thread":"%thread","traceId":"%X{traceId:-}","spanId":"%X{spanId:-}","msg":"%message"%nopex}%n</pattern>
+            </message>
+            <sortByTime>true</sortByTime>
+        </format>
+    </appender>
+
+    <!-- ── Async wrapper for Loki (non-blocking) ─────────────────────────── -->
+    <appender name="LOKI_ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="LOKI"/>
+        <queueSize>512</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+    </appender>
+
+    <!-- ── Root logger ────────────────────────────────────────────────────── -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="LOKI_ASYNC"/>
+    </root>
+
+    <!-- Reduce Spring/Hibernate noise -->
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="org.hibernate"       level="WARN"/>
+    <logger name="com.aiarchitect.rag" level="INFO"/>
+    <logger name="org.springframework.ai" level="INFO"/>
+</configuration>

--- a/ai-architect/rag-report-analyzer/backend/src/test/java/com/aiarchitect/rag/report/vectorstore/ChromaVectorStoreAdapterTest.java
+++ b/ai-architect/rag-report-analyzer/backend/src/test/java/com/aiarchitect/rag/report/vectorstore/ChromaVectorStoreAdapterTest.java
@@ -1,6 +1,7 @@
 package com.aiarchitect.rag.report.vectorstore;
 
 import com.aiarchitect.rag.report.infrastructure.adapter.out.vectorstore.ChromaVectorStoreAdapter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,7 +34,7 @@ class ChromaVectorStoreAdapterTest {
     @BeforeEach
     void setUp() {
         vectorStore = mock(VectorStore.class);
-        adapter = new ChromaVectorStoreAdapter(vectorStore);
+        adapter = new ChromaVectorStoreAdapter(vectorStore, new SimpleMeterRegistry());
     }
 
     @Test

--- a/ai-architect/rag-report-analyzer/backend/src/test/java/com/aiarchitect/rag/report/vectorstore/SimpleVectorStoreAdapterTest.java
+++ b/ai-architect/rag-report-analyzer/backend/src/test/java/com/aiarchitect/rag/report/vectorstore/SimpleVectorStoreAdapterTest.java
@@ -1,6 +1,7 @@
 package com.aiarchitect.rag.report.vectorstore;
 
 import com.aiarchitect.rag.report.infrastructure.adapter.out.vectorstore.SimpleVectorStoreAdapter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,7 +49,7 @@ class SimpleVectorStoreAdapterTest {
                 keywordVector(inv.getArgument(0, Document.class).getText()));
 
         SimpleVectorStore vectorStore = SimpleVectorStore.builder(embeddingModel).build();
-        adapter = new SimpleVectorStoreAdapter(vectorStore);
+        adapter = new SimpleVectorStoreAdapter(vectorStore, new SimpleMeterRegistry());
     }
 
     @Test

--- a/ai-architect/rag-report-analyzer/backend/src/test/resources/logback-test.xml
+++ b/ai-architect/rag-report-analyzer/backend/src/test/resources/logback-test.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Test-only Logback config — overrides logback-spring.xml for all unit/integration tests.
+  Uses CONSOLE only; Loki appender is excluded so no network calls are made during tests
+  and Spring Boot 4's strict ERROR-level Logback status check does not fail the context.
+-->
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="org.hibernate"       level="WARN"/>
+    <logger name="com.aiarchitect.rag" level="INFO"/>
+    <logger name="org.springframework.ai" level="INFO"/>
+</configuration>

--- a/ai-architect/rag-report-analyzer/docker-compose.yml
+++ b/ai-architect/rag-report-analyzer/docker-compose.yml
@@ -21,6 +21,9 @@ services:
       - POSTGRES_DB=${POSTGRES_DB:-ragdb}
       - POSTGRES_USER=${POSTGRES_USER:-raguser}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-change-me}
+      # Observability — active when --profile observability is used; ignored otherwise
+      - OTLP_ENDPOINT=${OTLP_ENDPOINT:-http://tempo:4317}
+      - LOKI_URL=${LOKI_URL:-http://loki:3100}
     depends_on:
       chroma:
         condition: service_healthy
@@ -86,10 +89,83 @@ services:
     networks:
       - rag-network
 
+  # ── Observability stack (Layer 1–4) ──────────────────────────────────────
+  # Activate with: docker compose --profile observability up
+  # Grafana UI: http://localhost:3001  (admin / admin)
+
+  prometheus:
+    image: prom/prometheus:v2.53.0
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=7d'
+      - '--web.enable-lifecycle'
+    profiles:
+      - observability
+    networks:
+      - rag-network
+
+  tempo:
+    image: grafana/tempo:2.5.0
+    ports:
+      - "3200:3200"   # Tempo HTTP API
+      - "4317:4317"   # OTLP gRPC receiver
+    volumes:
+      - ./observability/tempo.yaml:/etc/tempo.yaml:ro
+      - tempo-data:/tmp/tempo
+    command: [ "-config.file=/etc/tempo.yaml" ]
+    profiles:
+      - observability
+    networks:
+      - rag-network
+
+  loki:
+    image: grafana/loki:3.1.0
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./observability/loki.yaml:/etc/loki/local-config.yaml:ro
+      - loki-data:/loki
+    command: [ "-config.file=/etc/loki/local-config.yaml" ]
+    profiles:
+      - observability
+    networks:
+      - rag-network
+
+  grafana:
+    image: grafana/grafana:11.1.0
+    ports:
+      - "3001:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor
+    volumes:
+      - ./observability/grafana/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./observability/grafana/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    depends_on:
+      - prometheus
+      - tempo
+      - loki
+    profiles:
+      - observability
+    networks:
+      - rag-network
+
 volumes:
   chroma-data:
   ollama-data:
   postgres-data:
+  prometheus-data:
+  tempo-data:
+  loki-data:
+  grafana-data:
 
 networks:
   rag-network:

--- a/ai-architect/rag-report-analyzer/observability/grafana/dashboards/dashboard-provider.yaml
+++ b/ai-architect/rag-report-analyzer/observability/grafana/dashboards/dashboard-provider.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: RAG Report Analyzer
+    orgId: 1
+    folder: RAG Report Analyzer
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/ai-architect/rag-report-analyzer/observability/grafana/dashboards/rag-report-analyzer.json
+++ b/ai-architect/rag-report-analyzer/observability/grafana/dashboards/rag-report-analyzer.json
@@ -1,0 +1,208 @@
+{
+  "title": "RAG Report Analyzer",
+  "uid": "rag-report-analyzer",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": { "list": [] },
+  "annotations": { "list": [] },
+  "panels": [
+    {
+      "id": 1,
+      "title": "HTTP Request Rate",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "rate(http_server_requests_seconds_count{application=\"rag-report-analyzer\"}[1m])",
+          "legendFormat": "{{method}} {{uri}} {{status}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "color": { "mode": "palette-classic" } }
+      }
+    },
+    {
+      "id": 2,
+      "title": "HTTP P99 Latency",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "histogram_quantile(0.99, rate(http_server_requests_seconds_bucket{application=\"rag-report-analyzer\"}[1m]))",
+          "legendFormat": "p99 {{uri}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s", "color": { "mode": "palette-classic" } }
+      }
+    },
+    {
+      "id": 3,
+      "title": "LLM Call Duration (p99)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "histogram_quantile(0.99, rate(llm_call_duration_seconds_bucket{application=\"rag-report-analyzer\"}[2m]))",
+          "legendFormat": "p99 {{operation}} ({{provider}})"
+        },
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "histogram_quantile(0.50, rate(llm_call_duration_seconds_bucket{application=\"rag-report-analyzer\"}[2m]))",
+          "legendFormat": "p50 {{operation}} ({{provider}})"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s", "color": { "mode": "palette-classic" } }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Vector Store Operation Duration (p99)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "histogram_quantile(0.99, rate(vector_store_operation_seconds_bucket{application=\"rag-report-analyzer\"}[2m]))",
+          "legendFormat": "p99 {{operation}} ({{type}})"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s", "color": { "mode": "palette-classic" } }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Cache Hit Ratio (qa-answers)",
+      "type": "gauge",
+      "gridPos": { "x": 0, "y": 16, "w": 6, "h": 6 },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "rate(cache_gets_total{application=\"rag-report-analyzer\",result=\"hit\"}[5m]) / rate(cache_gets_total{application=\"rag-report-analyzer\"}[5m])",
+          "legendFormat": "hit ratio"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "green", "value": 0.8 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Spring AI — Token Usage (tokens/min)",
+      "type": "timeseries",
+      "gridPos": { "x": 6, "y": 16, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "rate(spring_ai_chat_client_token_usage_total{application=\"rag-report-analyzer\"}[1m])",
+          "legendFormat": "{{token_type}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "short", "color": { "mode": "palette-classic" } }
+      }
+    },
+    {
+      "id": 7,
+      "title": "JVM Heap Used",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 22, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "jvm_memory_used_bytes{application=\"rag-report-analyzer\",area=\"heap\"}",
+          "legendFormat": "{{id}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "bytes", "color": { "mode": "palette-classic" } }
+      }
+    },
+    {
+      "id": 8,
+      "title": "JVM GC Pause Duration",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 22, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "rate(jvm_gc_pause_seconds_sum{application=\"rag-report-analyzer\"}[1m])",
+          "legendFormat": "{{action}} {{cause}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s", "color": { "mode": "palette-classic" } }
+      }
+    },
+    {
+      "id": 9,
+      "title": "Spring AI — Embedding Duration (p99)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 30, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "histogram_quantile(0.99, rate(spring_ai_embedding_model_observations_seconds_bucket{application=\"rag-report-analyzer\"}[2m]))",
+          "legendFormat": "p99 embedding"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s", "color": { "mode": "palette-classic" } }
+      }
+    },
+    {
+      "id": 10,
+      "title": "Spring AI — ChatClient Duration (p99)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 30, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "histogram_quantile(0.99, rate(spring_ai_chat_client_observations_seconds_bucket{application=\"rag-report-analyzer\"}[2m]))",
+          "legendFormat": "p99 chat-client"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s", "color": { "mode": "palette-classic" } }
+      }
+    },
+    {
+      "id": 11,
+      "title": "Recent Logs (Loki)",
+      "type": "logs",
+      "gridPos": { "x": 0, "y": 38, "w": 24, "h": 10 },
+      "targets": [
+        {
+          "datasource": { "uid": "loki" },
+          "expr": "{app=\"rag-report-analyzer\"} | json",
+          "legendFormat": ""
+        }
+      ],
+      "options": {
+        "showLabels": false,
+        "showTime": true,
+        "wrapLogMessage": true,
+        "dedupStrategy": "none"
+      }
+    }
+  ]
+}

--- a/ai-architect/rag-report-analyzer/observability/grafana/datasources/datasources.yaml
+++ b/ai-architect/rag-report-analyzer/observability/grafana/datasources/datasources.yaml
@@ -1,0 +1,46 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    url: http://prometheus:9090
+    access: proxy
+    isDefault: true
+    jsonData:
+      httpMethod: POST
+      exemplarTraceIdDestinations:
+        - name: traceID
+          datasourceUid: tempo
+
+  - name: Tempo
+    type: tempo
+    uid: tempo
+    url: http://tempo:3200
+    access: proxy
+    jsonData:
+      httpMethod: GET
+      tracesToLogsV2:
+        datasourceUid: loki
+        spanStartTimeShift: '-1m'
+        spanEndTimeShift: '1m'
+        filterByTraceID: true
+        filterBySpanID: false
+        customQuery: false
+      serviceMap:
+        datasourceUid: prometheus
+      nodeGraph:
+        enabled: true
+
+  - name: Loki
+    type: loki
+    uid: loki
+    url: http://loki:3100
+    access: proxy
+    jsonData:
+      derivedFields:
+        - matcherRegex: '"traceId":"([a-f0-9]+)"'
+          name: traceID
+          url: '$${__value.raw}'
+          datasourceUid: tempo
+          urlDisplayLabel: View in Tempo

--- a/ai-architect/rag-report-analyzer/observability/loki.yaml
+++ b/ai-architect/rag-report-analyzer/observability/loki.yaml
@@ -1,0 +1,29 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 24h

--- a/ai-architect/rag-report-analyzer/observability/prometheus.yml
+++ b/ai-architect/rag-report-analyzer/observability/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: rag-report-analyzer
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: [ 'backend:8080' ]
+    relabel_configs:
+      - source_labels: [ __address__ ]
+        target_label: instance

--- a/ai-architect/rag-report-analyzer/observability/tempo.yaml
+++ b/ai-architect/rag-report-analyzer/observability/tempo.yaml
@@ -1,0 +1,23 @@
+stream_over_http_enabled: true
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /tmp/tempo/blocks
+    wal:
+      path: /tmp/tempo/wal
+
+compactor:
+  compaction:
+    block_retention: 1h


### PR DESCRIPTION
## Summary

- **Layer 1 — Custom Micrometer timers**: `vector.store.operation` timer on both `SimpleVectorStoreAdapter` and `ChromaVectorStoreAdapter` (tagged `type`, `operation`); `llm.call.duration` timer on `SpringAiMetricsExtractionAdapter` and `LlmEvalJudgeAdapter`
- **Layer 2 — Distributed tracing**: `micrometer-tracing-bridge-otel` + `opentelemetry-exporter-otlp` → Grafana Tempo via OTLP gRPC (port 4317); sampling probability configurable via `TRACING_SAMPLING_PROBABILITY`
- **Layer 3 — Centralised log search**: Loki4j logback appender pushes JSON logs (with `traceId`/`spanId` from Micrometer MDC) to Grafana Loki; logs cross-linked to traces in Grafana
- **Layer 4 — Spring AI observations**: `spring.ai.chat.client.observations`, `vectorstore.observations`, `embedding.observations` activated via application.yml

**Grafana stack** (all under `--profile observability`): Prometheus (port 9090) + Grafana Tempo (port 3200/4317) + Grafana Loki (port 3100) + Grafana (port 3001, admin/admin). Auto-provisioned datasources with cross-linking (Prometheus ↔ Tempo ↔ Loki). Pre-built dashboard with 11 panels: HTTP rate/p99, LLM call p99, vector store p99, cache hit ratio, Spring AI token usage, JVM heap/GC, Spring AI ChatClient/Embedding durations, Loki log panel.

**Test fix**: Added `src/test/resources/logback-test.xml` (CONSOLE-only) to prevent Spring Boot 4.0's strict Logback ERROR-status check from failing tests when Loki is unreachable. 42/42 tests green.

## How to run with observability

```bash
docker compose --profile observability up
# Grafana: http://localhost:3001  (admin / admin)
# Prometheus: http://localhost:9090
# Tempo: http://localhost:3200
# Loki: http://localhost:3100
```

## Test plan

- [x] `./gradlew clean test` — 42 tests, 0 failures
- [ ] `docker compose --profile observability up` — all 4 services start
- [ ] `POST /api/v1/ingest` then `GET /api/v1/qa?...` — trace visible in Grafana Tempo
- [ ] Log line in Grafana Loki shows `traceId` field; clicking "View in Tempo" jumps to trace
- [ ] `/actuator/prometheus` — `llm_call_duration_seconds` and `vector_store_operation_seconds` metrics present
- [ ] Grafana dashboard "RAG Report Analyzer" loads with all 11 panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)