### PR TITLE
feat #30(terra-query): Phase 4 — RAGAS Evaluation Framework & Golden Dataset

### DIFF
--- a/.github/workflows/ci-terra-query.yml
+++ b/.github/workflows/ci-terra-query.yml
@@ -54,6 +54,78 @@ jobs:
             ai-architect/terra-query/terra-core/build/reports/tests/
             ai-architect/terra-query/terra-infrastructure/build/reports/tests/
 
+  ragas-canary:
+    name: RAGAS Canary Eval (10 questions)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: build-and-test
+    # Only run on PRs with real API keys available (skip on forks without secrets)
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+
+    defaults:
+      run:
+        working-directory: ai-architect/terra-query/terra-mcp
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install eval dependencies
+        run: pip install -r requirements-eval.txt
+
+      - name: Start terra-mcp server
+        working-directory: ai-architect/terra-query
+        run: docker compose up -d terra-mcp
+
+      - name: Wait for terra-mcp healthy
+        working-directory: ai-architect/terra-query
+        run: |
+          for i in $(seq 1 30); do
+            python -c "import socket; s=socket.socket(); s.settimeout(3); s.connect(('localhost',8200)); s.close(); print('MCP ready')" 2>/dev/null && break
+            echo "Waiting ($i/30)..."
+            sleep 10
+          done
+
+      - name: Run RAGAS canary eval (10 questions)
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          python -m eval.eval_runner --subset canary --output-file ragas-canary.json
+
+      - name: Publish canary results to summary
+        if: always()
+        run: |
+          if [ -f ragas-canary.json ]; then
+            echo "## RAGAS Canary (10 Q)" >> $GITHUB_STEP_SUMMARY
+            python -c "
+          import json
+          with open('ragas-canary.json') as f: d = json.load(f)
+          for m in d['metrics']:
+              icon = '✅' if m['status'] == 'PASS' else ('⚠️' if m['status'] == 'WARN' else '❌')
+              print(f\"{icon} **{m['name']}**: {m['score']:.3f}\")
+          " >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Upload canary results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ragas-canary-${{ github.run_number }}
+          path: ai-architect/terra-query/terra-mcp/ragas-canary.json
+
+      - name: Tear down MCP server
+        if: always()
+        working-directory: ai-architect/terra-query
+        run: docker compose down
+
   mutation-tests:
     name: PIT Mutation Testing (terra-core, target ≥55% kill)
     runs-on: ubuntu-latest

--- a/.github/workflows/eval-terra-query.yml
+++ b/.github/workflows/eval-terra-query.yml
@@ -1,0 +1,95 @@
+name: Eval — TerraQuery RAGAS Evaluation
+
+on:
+  schedule:
+    - cron: "0 2 * * *"   # Nightly at 02:00 UTC (full 30-question eval)
+  workflow_dispatch:
+    inputs:
+      subset:
+        description: "Question subset to evaluate"
+        required: false
+        default: "full"
+        type: choice
+        options:
+          - full
+          - canary
+  push:
+    branches: [ main ]
+    paths:
+      - "ai-architect/terra-query/terra-mcp/eval/**"
+      - "ai-architect/terra-query/terra-mcp/eval/golden_dataset.json"
+
+defaults:
+  run:
+    working-directory: ai-architect/terra-query/terra-mcp
+
+jobs:
+  ragas-eval:
+    name: RAGAS Evaluation (${{ github.event.inputs.subset || 'full' }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install eval dependencies
+        run: pip install -r requirements-eval.txt
+
+      - name: Start terra-mcp server
+        working-directory: ai-architect/terra-query
+        run: docker compose up -d terra-mcp
+
+      - name: Wait for terra-mcp healthy
+        working-directory: ai-architect/terra-query
+        run: |
+          for i in $(seq 1 30); do
+            python -c "import socket; s=socket.socket(); s.settimeout(3); s.connect(('localhost',8200)); s.close(); print('MCP server ready')" 2>/dev/null && break
+            echo "Waiting for MCP server ($i/30)..."
+            sleep 10
+          done
+
+      - name: Run RAGAS evaluation
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          EVAL_SUBSET: ${{ github.event.inputs.subset || 'full' }}
+        run: |
+          python -m eval.eval_runner \
+            --subset "$EVAL_SUBSET" \
+            --output-file ragas-results.json
+
+      - name: Publish results to GitHub Actions summary
+        if: always()
+        run: |
+          if [ -f ragas-results.json ]; then
+            echo "## RAGAS Evaluation — $(date -u '+%Y-%m-%d %H:%M UTC')" >> $GITHUB_STEP_SUMMARY
+            python -c "
+          import json, sys
+          with open('ragas-results.json') as f:
+              data = json.load(f)
+          print(f\"**Subset:** {data['subset']} ({data['sample_count']} samples)\n\")
+          print('| Metric | Score | Target | Min | Status |')
+          print('|--------|-------|--------|-----|--------|')
+          for m in data['metrics']:
+              icon = '✅' if m['status'] == 'PASS' else ('⚠️' if m['status'] == 'WARN' else '❌')
+              print(f\"| {m['name']} | {m['score']:.3f} | ≥{m['threshold']:.2f} | ≥{m['min_threshold']:.2f} | {icon} {m['status']} |\")
+          " >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Upload RAGAS results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ragas-results-${{ github.run_number }}
+          path: ai-architect/terra-query/terra-mcp/ragas-results.json
+
+      - name: Tear down MCP server
+        if: always()
+        working-directory: ai-architect/terra-query
+        run: docker compose down

--- a/ai-architect/terra-query/terra-infrastructure/build.gradle.kts
+++ b/ai-architect/terra-query/terra-infrastructure/build.gradle.kts
@@ -81,6 +81,7 @@ tasks.register<Test>("liveTest") {
         includeTags("live-llm")
     }
     systemProperty("spring.profiles.active", "live-test")
+    systemProperty("eval.subset", findProperty("subset") ?: "canary")
 }
 
 pitest {

--- a/ai-architect/terra-query/terra-infrastructure/src/test/java/com/aiarchitect/terraquery/live/EvalConfig.java
+++ b/ai-architect/terra-query/terra-infrastructure/src/test/java/com/aiarchitect/terraquery/live/EvalConfig.java
@@ -1,0 +1,35 @@
+package com.aiarchitect.terraquery.live;
+
+import org.springframework.ai.anthropic.AnthropicChatModel;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Cross-provider evaluation configuration for live LLM tests.
+ *
+ * Generator: OpenAI gpt-4o-mini — produces answers from retrieved contexts.
+ * Evaluator: Anthropic claude-haiku — scores answer quality (avoids self-evaluation bias).
+ *
+ * Both providers are configured in application-live-test.yml.
+ * The primary ChatModel (used by the agent pipeline) is still selected
+ * via terra-query.ai.provider — these beans are supplementary, named beans
+ * used only by LiveLlmEvalTest for explicit cross-provider scoring.
+ */
+@TestConfiguration
+public class EvalConfig {
+
+    /** Generator model: OpenAI gpt-4o-mini — cheap, fast, produces answers. */
+    @Bean("generatorChatModel")
+    public ChatModel generatorChatModel(OpenAiChatModel openAiChatModel) {
+        return openAiChatModel;
+    }
+
+    /** Evaluator model: Anthropic claude-haiku — independent scorer, no self-eval bias. */
+    @Bean("evaluatorChatModel")
+    public ChatModel evaluatorChatModel(AnthropicChatModel anthropicChatModel) {
+        return anthropicChatModel;
+    }
+}

--- a/ai-architect/terra-query/terra-infrastructure/src/test/java/com/aiarchitect/terraquery/live/LiveLlmEvalTest.java
+++ b/ai-architect/terra-query/terra-infrastructure/src/test/java/com/aiarchitect/terraquery/live/LiveLlmEvalTest.java
@@ -1,0 +1,159 @@
+package com.aiarchitect.terraquery.live;
+
+import com.aiarchitect.terraquery.model.AgentResponse;
+import com.aiarchitect.terraquery.port.in.ChatUseCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+/**
+ * Live LLM evaluation tests — require real API keys + running terra-mcp server.
+ *
+ * Subset control via system property {@code eval.subset}:
+ *   canary  — first 10 questions (runs on every PR, fast)
+ *   full    — all 30 questions  (runs nightly)
+ *
+ * Run locally:
+ *   OPENAI_API_KEY=... ANTHROPIC_API_KEY=... \
+ *   ./gradlew :terra-infrastructure:liveTest -Psubset=canary
+ *
+ * Generator (OpenAI gpt-4o-mini) produces the answer via the full agent pipeline.
+ * Evaluator (Anthropic claude-haiku) scores relevance — cross-provider to avoid self-eval bias.
+ * Detailed RAGAS scoring (context precision/recall/faithfulness) runs in Python eval_runner.py.
+ */
+@Tag("live-llm")
+@SpringBootTest
+@ActiveProfiles("live-test")
+@Import(EvalConfig.class)
+class LiveLlmEvalTest {
+
+    private static final String GOLDEN_DATASET = "golden_dataset.json";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Autowired
+    ChatUseCase chatUseCase;
+
+    @Qualifier("evaluatorChatModel")
+    @Autowired
+    ChatModel evaluatorChatModel;
+
+    // ── Question loading ──────────────────────────────────────────────────────
+
+    static Stream<QuestionEntry> goldenQuestions() {
+        String subset = System.getProperty("eval.subset", "canary");
+        int limit = "full".equals(subset) ? 30 : 10;
+        return loadGoldenDataset().stream().limit(limit);
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("goldenQuestions")
+    void question_agentAnswers_nonEmptyAndCoherent(QuestionEntry entry) {
+        AgentResponse response = chatUseCase.chat(entry.question(), null);
+
+        assertThat(response).isNotNull();
+        assertThat(response.answer())
+                .as("Answer for question '%s' must not be blank", entry.id())
+                .isNotBlank();
+        assertThat(response.answer().length())
+                .as("Answer must be substantial (>50 chars) for question '%s'", entry.id())
+                .isGreaterThan(50);
+        assertThat(response.answer().toLowerCase())
+                .as("Answer must not be an error message for question '%s'", entry.id())
+                .doesNotContain("error", "sorry, i cannot", "i don't have access");
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("goldenQuestions")
+    void question_evaluatorScores_aboveRelevanceFloor(QuestionEntry entry) {
+        // Uses evaluator LLM (Anthropic claude-haiku) to score answer relevance independently.
+        // This is a lightweight proxy check; full RAGAS scoring runs in Python eval_runner.py.
+        AgentResponse response = chatUseCase.chat(entry.question(), null);
+        assumeThat(response.answer()).isNotBlank();
+
+        String evalPrompt = """
+                You are evaluating whether an answer is relevant to the question asked.
+                Question: %s
+                Expected answer (ground truth): %s
+                Actual answer: %s
+
+                Reply with only a single integer from 1 (completely irrelevant) to 5 (highly relevant).
+                """.formatted(entry.question(), entry.groundTruth(), response.answer());
+
+        String scoreStr = evaluatorChatModel
+                .call(new Prompt(evalPrompt))
+                .getResult()
+                .getOutput()
+                .getText()
+                .trim()
+                .replaceAll("[^1-5]", "");
+
+        assertThat(scoreStr)
+                .as("Evaluator must return a score 1-5 for question '%s'", entry.id())
+                .matches("[1-5]");
+
+        int score = Integer.parseInt(scoreStr);
+        assertThat(score)
+                .as("Relevance score must be ≥3 for question '%s' — got %d", entry.id(), score)
+                .isGreaterThanOrEqualTo(3);
+    }
+
+    @Test
+    void agentChain_allQuestionsUseExpectedAgents() {
+        QuestionEntry first = loadGoldenDataset().getFirst();
+        AgentResponse response = chatUseCase.chat(first.question(), null);
+        assertThat(response.agentChain())
+                .containsExactly("SupervisorAgent", "DataRetrievalAgent", "AnalysisSynthesisAgent");
+    }
+
+    // ── Dataset loading ───────────────────────────────────────────────────────
+
+    static List<QuestionEntry> loadGoldenDataset() {
+        try (InputStream is = LiveLlmEvalTest.class.getClassLoader()
+                .getResourceAsStream(GOLDEN_DATASET)) {
+            if (is == null) {
+                throw new IllegalStateException(
+                        "golden_dataset.json not found on classpath — "
+                        + "check terra-infrastructure/src/test/resources/");
+            }
+            JsonNode root = MAPPER.readTree(is);
+            List<QuestionEntry> entries = new ArrayList<>();
+            for (JsonNode node : root) {
+                entries.add(new QuestionEntry(
+                        node.get("id").asText(),
+                        node.get("question").asText(),
+                        node.get("ground_truth").asText()
+                ));
+            }
+            return entries;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load golden dataset", e);
+        }
+    }
+
+    record QuestionEntry(String id, String question, String groundTruth) {
+        @Override
+        public String toString() {
+            return id + ": " + question.substring(0, Math.min(60, question.length()));
+        }
+    }
+}

--- a/ai-architect/terra-query/terra-infrastructure/src/test/resources/application-live-test.yml
+++ b/ai-architect/terra-query/terra-infrastructure/src/test/resources/application-live-test.yml
@@ -1,0 +1,44 @@
+spring:
+  ai:
+    mcp:
+      client:
+        transport:
+          streamable-http:
+            connections:
+              terra-mcp:
+                url: http://localhost:8200/mcp
+    openai:
+      api-key: ${OPENAI_API_KEY}
+      chat:
+        options:
+          model: gpt-4o-mini
+          temperature: 0.0
+          max-tokens: 1024
+    anthropic:
+      api-key: ${ANTHROPIC_API_KEY}
+      chat:
+        options:
+          model: claude-haiku-4-5-20251001
+          temperature: 0.0
+          max-tokens: 256
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+
+terra-query:
+  ai:
+    provider: openai
+  agent:
+    guardrails:
+      max-supervisor-delegations: 3
+      max-retrieval-tool-calls: 8
+      max-analysis-tool-calls: 4
+      max-output-tokens: 1024
+      max-context-window-usage-percent: 80
+      context-window-strategy: HYBRID
+      sliding-window-size: 10
+      max-queries-per-minute: 60
+      daily-cost-cap-usd: 10.00
+      agent-timeout-seconds: 60
+  conversation:
+    persistence-scope: MESSAGES_ONLY

--- a/ai-architect/terra-query/terra-infrastructure/src/test/resources/golden_dataset.json
+++ b/ai-architect/terra-query/terra-infrastructure/src/test/resources/golden_dataset.json
@@ -1,0 +1,212 @@
+[
+  {
+    "id": "gd-001",
+    "question": "How many flood events were recorded in Bangladesh between 1990 and 2021?",
+    "ground_truth": "Bangladesh experienced over 100 flood events between 1990 and 2021 according to EM-DAT records. Flood frequency increased over this period, with approximately 8 events per year in the 1990s rising to around 14 events per year in the 2010s. Bangladesh is among the most flood-prone countries globally due to its delta geography.",
+    "context_docs": ["EM-DAT flood events Bangladesh 1990-2021", "EOSDIS flood records South Asia"],
+    "verification_sources": ["EM-DAT", "Wikipedia: Floods in Bangladesh"]
+  },
+  {
+    "id": "gd-002",
+    "question": "How many earthquake disasters occurred in Asia between 2000 and 2020?",
+    "ground_truth": "Asia recorded hundreds of significant earthquake disasters between 2000 and 2020 per EM-DAT. The region is seismically the most active in the world, with major events including the 2004 Indian Ocean earthquake (Mw 9.1), the 2008 Sichuan earthquake (Mw 7.9), the 2011 Tōhoku earthquake (Mw 9.0), and the 2015 Nepal earthquake (Mw 7.8).",
+    "context_docs": ["EM-DAT earthquake events Asia 2000-2020", "USGS earthquake catalog Asia"],
+    "verification_sources": ["EM-DAT", "USGS Earthquake Hazards Program"]
+  },
+  {
+    "id": "gd-003",
+    "question": "Which year had the most recorded natural disaster deaths globally in the 21st century?",
+    "ground_truth": "2004 was among the deadliest years for natural disasters in the 21st century, primarily due to the Indian Ocean tsunami on December 26 which killed over 227,000 people across 14 countries. Other extremely deadly years include 2008 (Cyclone Nargis + Sichuan earthquake) and 2010 (Haiti earthquake, which killed over 220,000 people).",
+    "context_docs": ["EM-DAT annual disaster statistics 2000-2021", "OFDA/CRED global disaster data"],
+    "verification_sources": ["EM-DAT", "Wikipedia: List of deadliest natural disasters"]
+  },
+  {
+    "id": "gd-004",
+    "question": "How many tropical storm events hit the Caribbean region between 1990 and 2010?",
+    "ground_truth": "The Caribbean experienced dozens of significant tropical storms and hurricanes between 1990 and 2010. Notable events include Hurricane Georges (1998), Hurricane Mitch (1998, killed ~11,000), Hurricane Ivan (2004), Hurricane Katrina (2005, affected Caribbean before hitting the US), and Hurricane Dean (2007). The Atlantic hurricane season produces an average of 12 named storms per year.",
+    "context_docs": ["NOAA Atlantic hurricane records 1990-2010", "EM-DAT storm events Caribbean"],
+    "verification_sources": ["NOAA National Hurricane Center", "EM-DAT"]
+  },
+  {
+    "id": "gd-005",
+    "question": "How many drought events were recorded in Africa during the 2000s?",
+    "ground_truth": "Africa recorded numerous significant drought events during the 2000s per EM-DAT. Major droughts affected the Sahel, Horn of Africa (particularly 2002-2003 and 2005-2006), and Southern Africa. The 2002-2003 southern African drought affected over 14 million people across multiple countries. Africa consistently accounts for the highest number of drought-affected people globally.",
+    "context_docs": ["EM-DAT drought events Africa 2000-2009", "FEWS NET drought records Africa"],
+    "verification_sources": ["EM-DAT", "FAO drought assessments Africa"]
+  },
+  {
+    "id": "gd-006",
+    "question": "How many volcanic eruptions were recorded globally since 1990 that caused casualties?",
+    "ground_truth": "Since 1990, dozens of volcanic eruptions have caused casualties globally according to EM-DAT and the Smithsonian Global Volcanism Program. Major deadly eruptions include Pinatubo (1991, Philippines, ~800 deaths), Ruapehu (1996, New Zealand), Merapi (2010, Indonesia, ~350 deaths), and Ontake (2014, Japan, 57 deaths). Indonesia, Philippines, and Japan account for the majority of deadly eruptions.",
+    "context_docs": ["EM-DAT volcanic eruption records 1990-2023", "Smithsonian Global Volcanism Program"],
+    "verification_sources": ["EM-DAT", "Smithsonian Global Volcanism Program"]
+  },
+  {
+    "id": "gd-007",
+    "question": "What was the deadliest earthquake of the 21st century in terms of fatalities?",
+    "ground_truth": "The 2010 Haiti earthquake (magnitude 7.0, January 12) is the deadliest earthquake of the 21st century, killing an estimated 220,000–316,000 people. It struck near Port-au-Prince. The second deadliest was the 2004 Indian Ocean earthquake and tsunami (magnitude 9.1) which caused over 227,000 deaths across 14 countries.",
+    "context_docs": ["EM-DAT earthquake deaths 2000-2021", "USGS earthquake catalog"],
+    "verification_sources": ["EM-DAT", "USGS", "Wikipedia: 2010 Haiti earthquake"]
+  },
+  {
+    "id": "gd-008",
+    "question": "How many people were killed by the 2004 Indian Ocean tsunami?",
+    "ground_truth": "The 2004 Indian Ocean tsunami (triggered by a magnitude 9.1 earthquake off the coast of Sumatra on December 26) killed approximately 227,898 people across 14 countries. Indonesia suffered the most deaths (~167,000), followed by Sri Lanka (~35,000), India (~12,400), and Thailand (~5,400). It is the deadliest tsunami in recorded history.",
+    "context_docs": ["EM-DAT 2004 Indian Ocean disaster", "USGS 2004 Sumatra earthquake"],
+    "verification_sources": ["EM-DAT", "USGS", "Wikipedia: 2004 Indian Ocean earthquake and tsunami"]
+  },
+  {
+    "id": "gd-009",
+    "question": "What disaster caused the highest death toll in Haiti's recorded history?",
+    "ground_truth": "The 2010 Haiti earthquake (January 12, magnitude 7.0) caused the highest death toll in Haiti's history, killing an estimated 220,000 to 316,000 people. It also injured approximately 300,000, displaced 1.5 million, and caused around $8 billion in economic damage. The earthquake struck near Port-au-Prince and was devastating due to poor building construction and high urban density.",
+    "context_docs": ["EM-DAT Haiti disaster history", "USGS 2010 Haiti earthquake"],
+    "verification_sources": ["EM-DAT", "Wikipedia: 2010 Haiti earthquake", "World Bank Haiti"]
+  },
+  {
+    "id": "gd-010",
+    "question": "How many people were killed by Hurricane Katrina in 2005?",
+    "ground_truth": "Hurricane Katrina caused approximately 1,833 direct deaths in the United States in August–September 2005, making it the deadliest Atlantic hurricane since 1928. The majority of deaths occurred in Louisiana (1,577), particularly in New Orleans where levee failures caused catastrophic flooding. It also caused about $125 billion in economic damage, making it one of the costliest natural disasters in US history.",
+    "context_docs": ["NOAA Hurricane Katrina 2005 data", "EM-DAT storm USA 2005"],
+    "verification_sources": ["NOAA National Hurricane Center", "EM-DAT", "Wikipedia: Hurricane Katrina"]
+  },
+  {
+    "id": "gd-011",
+    "question": "What was the death toll from the 1998 Bangladesh floods?",
+    "ground_truth": "The 1998 Bangladesh floods were among the worst in the country's history, lasting from July to September and submerging about two-thirds of the country. The floods killed approximately 1,000–1,100 people directly and left about 30 million people homeless. Economic damage was estimated at nearly $6 billion. The disaster prompted major flood management investments in Bangladesh.",
+    "context_docs": ["EM-DAT Bangladesh flood 1998", "EOSDIS 1998 Bangladesh flood"],
+    "verification_sources": ["EM-DAT", "Wikipedia: 1998 Bangladesh floods", "ReliefWeb"]
+  },
+  {
+    "id": "gd-012",
+    "question": "How many people died in the 2008 Sichuan earthquake in China?",
+    "ground_truth": "The 2008 Sichuan earthquake (magnitude 7.9, May 12) killed approximately 69,197 people, with 374,171 injured and 18,222 missing. It was the deadliest earthquake in China since the 1976 Tangshan earthquake. The disaster caused an estimated $85 billion in economic damage. School collapses drew international criticism, contributing to subsequent building code reforms in China.",
+    "context_docs": ["EM-DAT China earthquake 2008", "USGS 2008 Sichuan earthquake"],
+    "verification_sources": ["EM-DAT", "USGS", "Wikipedia: 2008 Sichuan earthquake"]
+  },
+  {
+    "id": "gd-013",
+    "question": "What was the most economically damaging storm in US history?",
+    "ground_truth": "Hurricane Katrina (2005) is generally considered the most economically damaging storm in US history, causing approximately $125 billion in damage (2005 USD), or over $180 billion in 2023 dollars. Hurricane Harvey (2017) is close behind with ~$125 billion in damage. Other extremely costly storms include Hurricane Maria (2017, ~$90 billion) and Hurricane Sandy (2012, ~$65 billion).",
+    "context_docs": ["NOAA US billion-dollar disaster database", "EM-DAT storm USA economic damage"],
+    "verification_sources": ["NOAA NCEI Billion-Dollar Disasters", "EM-DAT"]
+  },
+  {
+    "id": "gd-014",
+    "question": "How much economic damage did the 2011 Japan earthquake and tsunami cause?",
+    "ground_truth": "The 2011 Tōhoku earthquake and tsunami (March 11, magnitude 9.0) caused approximately $235 billion in economic damage, making it the costliest natural disaster in history at the time. The World Bank estimated reconstruction costs at $235 billion. The event killed approximately 15,899 people and triggered the Fukushima Daiichi nuclear disaster.",
+    "context_docs": ["EM-DAT Japan earthquake tsunami 2011", "World Bank Japan disaster assessment 2011"],
+    "verification_sources": ["EM-DAT", "World Bank", "Wikipedia: 2011 Tōhoku earthquake"]
+  },
+  {
+    "id": "gd-015",
+    "question": "What was the total economic damage from floods globally in the 2010s?",
+    "ground_truth": "Global flood damage totaled hundreds of billions of dollars during the 2010s. The 2011 Thailand floods alone caused approximately $40 billion in damage. NOAA and Munich Re data suggest global flood losses averaged over $40 billion per year during the 2010s. Asia (particularly China, India, and Thailand) accounted for the majority of flood economic losses during this period.",
+    "context_docs": ["EM-DAT global flood economic damage 2010-2019", "Munich Re NatCat flood data 2010s"],
+    "verification_sources": ["EM-DAT", "Munich Re NatCatSERVICE", "Swiss Re sigma report"]
+  },
+  {
+    "id": "gd-016",
+    "question": "How does economic damage from storms compare to floods in North America?",
+    "ground_truth": "In North America, storms (hurricanes, tornadoes, severe thunderstorms) typically cause far more economic damage than floods. NOAA data shows storms account for roughly 70-80% of total natural disaster economic losses in the US, while floods account for 10-15%. Hurricanes like Katrina ($125B), Harvey ($125B), and Maria ($90B) dwarf individual flood events in economic impact.",
+    "context_docs": ["NOAA billion-dollar disaster types USA", "EM-DAT storm vs flood North America"],
+    "verification_sources": ["NOAA NCEI Billion-Dollar Disasters", "EM-DAT"]
+  },
+  {
+    "id": "gd-017",
+    "question": "Which country suffered the most economic damage from natural disasters in the 2000s?",
+    "ground_truth": "The United States suffered the most absolute economic damage from natural disasters in the 2000s, primarily from Hurricane Katrina (2005, ~$125B) and other major storms. However, relative to GDP, developing nations fared worse. China also experienced enormous losses from the 2008 Sichuan earthquake (~$85B). Japan, Haiti, and Indonesia also suffered catastrophic losses relative to their economies.",
+    "context_docs": ["EM-DAT economic damage by country 2000-2009", "Munich Re disaster economics 2000s"],
+    "verification_sources": ["EM-DAT", "Munich Re NatCatSERVICE", "Swiss Re"]
+  },
+  {
+    "id": "gd-018",
+    "question": "What was the economic impact of the 2010 Haiti earthquake?",
+    "ground_truth": "The 2010 Haiti earthquake caused approximately $7.8–$8 billion in economic damage, equivalent to over 100% of Haiti's GDP at the time. The World Bank estimated reconstruction needs at $11.5 billion. Port-au-Prince's infrastructure was devastated, including government buildings, hospitals, and over 100,000 homes. Haiti received roughly $13 billion in international aid pledges for reconstruction.",
+    "context_docs": ["EM-DAT Haiti earthquake 2010 economic impact", "World Bank Haiti post-disaster assessment"],
+    "verification_sources": ["EM-DAT", "World Bank", "Wikipedia: 2010 Haiti earthquake"]
+  },
+  {
+    "id": "gd-019",
+    "question": "Which disaster type causes more average deaths per event: earthquakes or storms?",
+    "ground_truth": "Earthquakes historically cause more deaths per event than storms on average, primarily because major earthquakes strike without warning and can cause catastrophic building collapse. EM-DAT data shows earthquakes average thousands of deaths per significant event (e.g., 2010 Haiti ~220,000; 2004 Indian Ocean ~228,000). Storms cause more deaths in aggregate annually but are more survivable individually, especially in countries with early warning systems.",
+    "context_docs": ["EM-DAT deaths by disaster type comparison", "CRED disaster statistics mortality"],
+    "verification_sources": ["EM-DAT / CRED", "UNDRR Global Assessment Report"]
+  },
+  {
+    "id": "gd-020",
+    "question": "How do floods compare to droughts in terms of people affected globally?",
+    "ground_truth": "Droughts affect far more people globally than floods in terms of total affected population. EM-DAT data shows droughts affect hundreds of millions annually, particularly in Africa and Asia, because they impact large agricultural areas over extended periods. Floods, while causing more deaths and economic damage, typically affect smaller geographic areas. Droughts accounted for roughly 35-40% of all disaster-affected people globally in the 2000s-2010s.",
+    "context_docs": ["EM-DAT affected population floods vs droughts", "CRED disaster type statistics"],
+    "verification_sources": ["EM-DAT", "CRED", "UNDRR Global Assessment Report"]
+  },
+  {
+    "id": "gd-021",
+    "question": "Which disaster type is most common in Southeast Asia?",
+    "ground_truth": "Floods are the most common disaster type in Southeast Asia by event count, according to EM-DAT. The region's monsoon climate, low-lying deltas (Mekong, Irrawaddy, Chao Phraya), and dense coastal populations make flooding the dominant hazard. Storms (tropical cyclones) are the second most frequent and most deadly disaster type. The Philippines, Vietnam, Indonesia, and Bangladesh are among the most disaster-affected countries in the region.",
+    "context_docs": ["EM-DAT Southeast Asia disaster types", "UNDRR Asia Pacific disaster data"],
+    "verification_sources": ["EM-DAT", "UNDRR", "ESCAP Disaster Statistics"]
+  },
+  {
+    "id": "gd-022",
+    "question": "Are wildfires or storms more frequent in North America?",
+    "ground_truth": "Storms are significantly more frequent than wildfires as recorded disaster events in North America. NOAA data shows the US alone averages 10–15 billion-dollar storm events per year, while wildfires average 1–3. However, wildfire frequency has increased dramatically since 2010 in western North America due to drought and climate change. The 2017-2020 California wildfire seasons were record-breaking, with 2020 burning over 4 million acres.",
+    "context_docs": ["NOAA US disaster frequency storms vs wildfires", "EM-DAT North America wildfire storm events"],
+    "verification_sources": ["NOAA NCEI Billion-Dollar Disasters", "Cal Fire statistics", "EM-DAT"]
+  },
+  {
+    "id": "gd-023",
+    "question": "How do earthquake mortality rates differ between developed and developing countries?",
+    "ground_truth": "Earthquake mortality rates are dramatically higher in developing countries than in developed ones for comparable-magnitude events. The 2010 Haiti earthquake (M7.0) killed ~220,000 people; a similar-magnitude event in California (e.g., 1989 Loma Prieta, M6.9) killed 63. This disparity reflects building construction quality, enforcement of seismic codes, emergency response capacity, and healthcare infrastructure. Japan's M9.0 2011 earthquake caused ~15,900 deaths; a similar event in an unprep country could cause millions.",
+    "context_docs": ["EM-DAT earthquake mortality developed vs developing", "USGS seismic risk global comparison"],
+    "verification_sources": ["EM-DAT", "USGS", "World Bank seismic risk report"]
+  },
+  {
+    "id": "gd-024",
+    "question": "Which region experiences the most earthquake events globally?",
+    "ground_truth": "The Asia-Pacific region (including the Ring of Fire countries: Japan, Indonesia, Philippines, China, New Zealand) experiences the most earthquake events globally by frequency and total energy released. Indonesia and Japan are the most earthquake-prone countries. The Ring of Fire accounts for approximately 90% of the world's earthquakes and about 80% of the world's largest earthquakes. Chile, Peru, and the western US also experience high seismic activity.",
+    "context_docs": ["USGS global earthquake frequency by region", "EM-DAT earthquake events by region"],
+    "verification_sources": ["USGS Earthquake Hazards Program", "EM-DAT", "British Geological Survey"]
+  },
+  {
+    "id": "gd-025",
+    "question": "Has the frequency of natural disasters increased since 1990?",
+    "ground_truth": "Recorded natural disaster events increased substantially from 1990 to approximately 2005, then plateaued and slightly declined in reported events. EM-DAT data shows recorded disasters rose from ~200/year in 1990 to a peak of ~450/year around 2000–2005, partly reflecting improved reporting. Climate-sensitive disasters (floods, storms, extreme temperatures) have increased in frequency, while geological disasters (earthquakes, volcanoes) show no long-term trend.",
+    "context_docs": ["EM-DAT disaster frequency 1990-2021 annual statistics", "CRED disaster trends report"],
+    "verification_sources": ["EM-DAT", "CRED", "UNDRR Global Assessment Report 2022"]
+  },
+  {
+    "id": "gd-026",
+    "question": "Are storm intensities increasing over time due to climate change?",
+    "ground_truth": "Scientific consensus indicates that while total storm frequency may not be increasing significantly, the proportion of high-intensity storms (Category 4–5 hurricanes) is increasing due to warmer ocean temperatures. The 2021 IPCC AR6 report states with high confidence that the proportion of intense tropical cyclones and associated heavy precipitation have increased globally since the 1980s. Economic losses from storms have grown significantly due to both increased intensity and coastal development.",
+    "context_docs": ["NOAA historical hurricane intensity trends", "EM-DAT storm damage trends 1990-2021"],
+    "verification_sources": ["IPCC AR6 2021", "NOAA National Hurricane Center", "Nature Climate Change studies"]
+  },
+  {
+    "id": "gd-027",
+    "question": "How has flood frequency in South Asia changed over the past 30 years?",
+    "ground_truth": "Flood frequency and severity in South Asia has increased significantly over the past 30 years. EM-DAT data shows India, Bangladesh, and Pakistan report increasing numbers of significant flood events annually. The 2022 Pakistan super-floods affected one-third of the country (33 million people). Attribution studies link increased monsoon intensity to climate change. Bangladesh flood frequency roughly doubled between the 1990s and 2010s.",
+    "context_docs": ["EM-DAT South Asia flood frequency 1990-2022", "EOSDIS flood events India Bangladesh Pakistan"],
+    "verification_sources": ["EM-DAT", "ReliefWeb", "IPCC AR6 Chapter 11"]
+  },
+  {
+    "id": "gd-028",
+    "question": "What trends exist in disaster-related deaths over the past two decades?",
+    "ground_truth": "Disaster-related deaths show a declining long-term trend over the past two decades despite increasing event frequency, reflecting improved early warning systems, disaster preparedness, and resilience investments. EM-DAT data shows average annual deaths declined from ~100,000/year in the 1990s to ~60,000/year in the 2010s (excluding outlier years like 2004 and 2010). However, heat-related deaths are increasing, and climate impacts are projected to reverse these gains.",
+    "context_docs": ["EM-DAT global annual disaster deaths 2000-2021", "CRED disaster statistics mortality trends"],
+    "verification_sources": ["EM-DAT", "CRED", "UNDRR Global Assessment Report 2022"]
+  },
+  {
+    "id": "gd-029",
+    "question": "How has economic damage from natural disasters changed over the past 30 years?",
+    "ground_truth": "Economic losses from natural disasters have increased substantially over the past 30 years. Munich Re and Swiss Re data show global insured losses grew from an average of ~$50 billion/year in the 1990s to ~$100 billion/year in the 2010s (2023 USD). Total economic losses (insured + uninsured) roughly tripled over this period. Drivers include increased disaster intensity (climate change), rapid urbanization in risk zones, and rising asset values — not just increased reporting.",
+    "context_docs": ["EM-DAT global economic damage trend 1990-2021", "Munich Re NatCat annual report"],
+    "verification_sources": ["Munich Re NatCatSERVICE", "Swiss Re sigma", "EM-DAT"]
+  },
+  {
+    "id": "gd-030",
+    "question": "Are drought events becoming more frequent and severe in Africa?",
+    "ground_truth": "Yes, drought frequency and severity is increasing in parts of Africa, particularly in the Horn of Africa and southern Africa. The 2011 Horn of Africa drought was the worst in 60 years, affecting 13 million people. The 2022 Horn of Africa drought (5th consecutive failed rainy season) was declared the worst in 40 years. The IPCC AR6 projects higher drought frequency and intensity across most of Africa under all warming scenarios, with the southern Africa and Sahel regions most at risk.",
+    "context_docs": ["EM-DAT Africa drought events 1990-2022", "FEWS NET drought severity Africa"],
+    "verification_sources": ["EM-DAT", "FEWS NET", "IPCC AR6 Chapter 9 (Africa)"]
+  }
+]

--- a/ai-architect/terra-query/terra-mcp/eval/__init__.py
+++ b/ai-architect/terra-query/terra-mcp/eval/__init__.py
@@ -1,0 +1,1 @@
+"""TerraQuery RAGAS evaluation framework."""

--- a/ai-architect/terra-query/terra-mcp/eval/answer_generator.py
+++ b/ai-architect/terra-query/terra-mcp/eval/answer_generator.py
@@ -1,0 +1,168 @@
+"""Answer generator: retrieves contexts from MCP, produces answers via generator LLM."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Callable, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EvalSample:
+    """One evaluation sample ready for RAGAS scoring."""
+
+    question_id: str
+    question: str
+    ground_truth: str
+    contexts: list[str]
+    answer: str
+
+
+@runtime_checkable
+class ContextRetriever(Protocol):
+    """Pluggable context-retrieval strategy (injectable for testing)."""
+
+    def retrieve(self, question: str) -> list[str]:
+        ...
+
+
+class McpDirectRetriever:
+    """Retrieves contexts by importing terra-mcp search modules directly (no HTTP)."""
+
+    def __init__(self, repo, engine, top_k: int = 5) -> None:
+        self._repo = repo
+        self._engine = engine
+        self._top_k = top_k
+
+    def retrieve(self, question: str) -> list[str]:
+        if self._engine is None:
+            logger.warning("No search engine — contexts will be empty for question: %s", question)
+            return []
+        results = self._engine.search(question)
+        texts: list[str] = []
+        df = self._repo.df
+        for r in results[: self._top_k]:
+            record_id = r.get("record_id", "")
+            text = r.get("text", "")
+            if not df.empty and "event_id" in df.columns:
+                row_match = df[df["event_id"] == record_id]
+                if not row_match.empty:
+                    row = row_match.iloc[0]
+                    text = _row_to_context(row)
+            if text:
+                texts.append(text)
+        return texts
+
+
+def _row_to_context(row) -> str:
+    """Convert a disaster DataFrame row to a readable context string."""
+    import pandas as pd
+
+    def _fmt(val, suffix="") -> str:
+        try:
+            if pd.isna(val):
+                return "unknown"
+        except (TypeError, ValueError):
+            pass
+        if suffix:
+            return f"{val}{suffix}"
+        return str(val)
+
+    dtype = _fmt(row.get("disaster_type", "unknown")).title()
+    country = _fmt(row.get("country", "unknown"))
+    region = _fmt(row.get("region", "unknown"))
+    year = "unknown"
+    try:
+        ts = row.get("start_date")
+        if ts is not None and not pd.isna(ts):
+            year = str(pd.Timestamp(ts).year)
+    except Exception:
+        pass
+    deaths = _fmt(row.get("deaths"), " deaths")
+    damage = _fmt(row.get("economic_damage_usd"), " USD damage")
+    affected = _fmt(row.get("affected"), " affected")
+    mag = row.get("magnitude")
+    mag_str = f", magnitude {mag}" if mag and str(mag) != "unknown" else ""
+
+    return (
+        f"{dtype} in {country} ({region}), {year}. "
+        f"Deaths: {deaths}. Affected: {affected}. Economic damage: {damage}{mag_str}."
+    )
+
+
+class AnswerGenerator:
+    """Generates LLM answers for questions using retrieved contexts.
+
+    Uses the generator LLM (OpenAI gpt-4o-mini) to produce answers — separate
+    from the evaluator LLM (Anthropic claude-haiku) to eliminate self-eval bias.
+    """
+
+    _PROMPT_TEMPLATE = (
+        "You are a natural disaster information assistant. "
+        "Answer the question using ONLY the provided context. "
+        "If the context does not contain enough information, say so explicitly.\n\n"
+        "Context:\n{context}\n\n"
+        "Question: {question}\n\n"
+        "Answer:"
+    )
+
+    def __init__(
+        self,
+        retriever: ContextRetriever,
+        generator_llm_fn: Callable[[str], str],
+    ) -> None:
+        self._retriever = retriever
+        self._generate = generator_llm_fn
+
+    def generate_sample(self, question_id: str, question: str, ground_truth: str) -> EvalSample:
+        contexts = self._retriever.retrieve(question)
+        if not contexts:
+            logger.warning("No contexts retrieved for question %s: %s", question_id, question)
+            answer = "Insufficient context to answer this question."
+        else:
+            prompt = self._PROMPT_TEMPLATE.format(
+                context="\n\n".join(f"[{i+1}] {c}" for i, c in enumerate(contexts)),
+                question=question,
+            )
+            answer = self._generate(prompt)
+        return EvalSample(
+            question_id=question_id,
+            question=question,
+            ground_truth=ground_truth,
+            contexts=contexts,
+            answer=answer,
+        )
+
+    def generate_batch(
+        self,
+        entries: list[dict],
+    ) -> list[EvalSample]:
+        samples: list[EvalSample] = []
+        for entry in entries:
+            qid = entry["id"]
+            logger.info("Generating answer for %s", qid)
+            try:
+                sample = self.generate_sample(qid, entry["question"], entry["ground_truth"])
+                samples.append(sample)
+            except Exception as exc:
+                logger.error("Failed to generate sample for %s: %s", qid, exc)
+        return samples
+
+
+def build_openai_generator_fn(model: str, api_key: str) -> Callable[[str], str]:
+    """Return a callable that sends a prompt to OpenAI and returns the text response."""
+
+    def _call(prompt: str) -> str:
+        from openai import OpenAI
+
+        client = OpenAI(api_key=api_key)
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.0,
+            max_tokens=512,
+        )
+        return response.choices[0].message.content or ""
+
+    return _call

--- a/ai-architect/terra-query/terra-mcp/eval/eval_config.py
+++ b/ai-architect/terra-query/terra-mcp/eval/eval_config.py
@@ -1,0 +1,70 @@
+"""Evaluation configuration: thresholds, provider selection, dataset sizing."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class EvalThresholds:
+    """Pass/fail thresholds for RAGAS metrics.
+
+    Pass threshold: target score — regression alert if any metric drops below.
+    Min threshold: hard-fail floor (pass_threshold - 0.10) — CI blocks on breach.
+    """
+
+    context_precision: float = 0.80
+    context_recall: float = 0.75
+    faithfulness: float = 0.85
+    answer_relevance: float = 0.80
+
+    @property
+    def context_precision_min(self) -> float:
+        return self.context_precision - 0.10
+
+    @property
+    def context_recall_min(self) -> float:
+        return self.context_recall - 0.10
+
+    @property
+    def faithfulness_min(self) -> float:
+        return self.faithfulness - 0.10
+
+    @property
+    def answer_relevance_min(self) -> float:
+        return self.answer_relevance - 0.10
+
+    def min_for(self, metric: str) -> float:
+        return getattr(self, f"{metric}_min")
+
+    def target_for(self, metric: str) -> float:
+        return getattr(self, metric)
+
+
+@dataclass
+class EvalConfig:
+    """Cross-provider evaluation config (generator ≠ evaluator to eliminate self-eval bias).
+
+    Generator: OpenAI gpt-4o-mini — produces answers from retrieved contexts.
+    Evaluator: Anthropic claude-haiku — scores those answers via RAGAS metrics.
+    """
+
+    generator_model: str = "gpt-4o-mini"
+    evaluator_model: str = "claude-haiku-4-5-20251001"
+    openai_api_key: str = field(default_factory=lambda: os.environ.get("OPENAI_API_KEY", ""))
+    anthropic_api_key: str = field(default_factory=lambda: os.environ.get("ANTHROPIC_API_KEY", ""))
+    thresholds: EvalThresholds = field(default_factory=EvalThresholds)
+    canary_size: int = 10
+    full_size: int = 30
+    top_k_contexts: int = 5
+
+    @classmethod
+    def from_env(cls) -> "EvalConfig":
+        return cls()
+
+    def validate(self) -> None:
+        """Raise ValueError if required API keys are missing."""
+        if not self.openai_api_key:
+            raise ValueError("OPENAI_API_KEY not set — required for generator (gpt-4o-mini)")
+        if not self.anthropic_api_key:
+            raise ValueError("ANTHROPIC_API_KEY not set — required for evaluator (claude-haiku)")

--- a/ai-architect/terra-query/terra-mcp/eval/eval_runner.py
+++ b/ai-architect/terra-query/terra-mcp/eval/eval_runner.py
@@ -1,0 +1,156 @@
+"""CLI entrypoint for TerraQuery RAGAS evaluation.
+
+Usage:
+  python -m eval.eval_runner [--subset canary|full] [--output-file PATH]
+
+Subset:
+  canary  — first 10 questions (run on every PR)
+  full    — all 30 questions (run nightly)
+
+Exit codes:
+  0  all metrics >= target threshold (PASS)
+  1  any metric < min threshold (HARD FAIL — blocks CI)
+  2  some metrics below target but above min (WARN — prints but does not block)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+# Ensure project root on path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+_GOLDEN_DATASET_PATH = Path(__file__).parent / "golden_dataset.json"
+
+
+def load_golden_dataset(subset: str, config) -> list[dict]:
+    with open(_GOLDEN_DATASET_PATH, encoding="utf-8") as f:
+        entries: list[dict] = json.load(f)
+    size = config.canary_size if subset == "canary" else config.full_size
+    return entries[:size]
+
+
+def build_retriever(config):
+    """Build a McpDirectRetriever using the real terra-mcp data pipeline."""
+    from data.repository import DisasterRepository
+    from data.index.index_builder import build_indices
+    from data.index.index_cache import IndexCache
+    from search.hierarchical_chunker import HierarchicalChunker
+    from search.hybrid_search import HybridSearchEngine
+    from search.rrf_config import RRFConfig
+    from eval.answer_generator import McpDirectRetriever
+
+    logger.info("Loading disaster data for evaluation...")
+    repo = DisasterRepository()
+    repo.load()
+
+    engine = None
+    if not repo.df.empty:
+        chunker = HierarchicalChunker()
+        cache = IndexCache()
+        data_files = repo.get_data_file_paths()
+        data_hash = IndexCache.compute_data_hash(*data_files) if data_files else "default"
+        indices = cache.get_or_build(data_hash, lambda: build_indices(repo.df, chunker))
+        repo.set_indices(indices)
+        engine = HybridSearchEngine(indices=indices, config=RRFConfig.from_env())
+        logger.info("Search engine ready")
+
+    return McpDirectRetriever(repo, engine, top_k=config.top_k_contexts)
+
+
+def write_github_summary(summary_md: str) -> None:
+    """Append RAGAS results to GitHub Actions job summary if running in CI."""
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_file:
+        with open(summary_file, "a", encoding="utf-8") as f:
+            f.write("\n## RAGAS Evaluation Results\n\n")
+            f.write(summary_md)
+            f.write("\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="TerraQuery RAGAS evaluator")
+    parser.add_argument(
+        "--subset",
+        choices=["canary", "full"],
+        default=os.environ.get("EVAL_SUBSET", "canary"),
+        help="canary=10 questions (PR), full=30 questions (nightly)",
+    )
+    parser.add_argument(
+        "--output-file",
+        default=None,
+        help="Optional JSON file path to write full results",
+    )
+    args = parser.parse_args(argv)
+
+    from eval.eval_config import EvalConfig
+    from eval.answer_generator import AnswerGenerator, build_openai_generator_fn
+    from eval.ragas_evaluator import RagasEvaluator
+
+    config = EvalConfig.from_env()
+    try:
+        config.validate()
+    except ValueError as exc:
+        logger.error("Config error: %s", exc)
+        return 1
+
+    entries = load_golden_dataset(args.subset, config)
+    logger.info("Running %s eval — %d questions", args.subset, len(entries))
+
+    retriever = build_retriever(config)
+    generator_fn = build_openai_generator_fn(config.generator_model, config.openai_api_key)
+    generator = AnswerGenerator(retriever, generator_fn)
+
+    logger.info("Generating answers with %s...", config.generator_model)
+    samples = generator.generate_batch(entries)
+
+    if not samples:
+        logger.error("No samples generated — aborting evaluation")
+        return 1
+
+    logger.info("Running RAGAS evaluation with %s...", config.evaluator_model)
+    evaluator = RagasEvaluator(config)
+    result = evaluator.evaluate(samples)
+
+    print(result.to_summary())
+    write_github_summary(result.to_github_summary())
+
+    if args.output_file:
+        out = {
+            "subset": args.subset,
+            "sample_count": result.sample_count,
+            "metrics": [
+                {
+                    "name": m.name,
+                    "score": m.score,
+                    "threshold": m.threshold,
+                    "min_threshold": m.min_threshold,
+                    "status": m.status,
+                }
+                for m in result.metric_scores
+            ],
+        }
+        Path(args.output_file).write_text(json.dumps(out, indent=2), encoding="utf-8")
+        logger.info("Results written to %s", args.output_file)
+
+    if result.any_hard_fail:
+        logger.error("HARD FAIL: one or more metrics below minimum threshold")
+        return 1
+    if not result.all_pass:
+        logger.warning("WARN: some metrics below target threshold (above minimum)")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ai-architect/terra-query/terra-mcp/eval/golden_dataset.json
+++ b/ai-architect/terra-query/terra-mcp/eval/golden_dataset.json
@@ -1,0 +1,212 @@
+[
+  {
+    "id": "gd-001",
+    "question": "How many flood events were recorded in Bangladesh between 1990 and 2021?",
+    "ground_truth": "Bangladesh experienced over 100 flood events between 1990 and 2021 according to EM-DAT records. Flood frequency increased over this period, with approximately 8 events per year in the 1990s rising to around 14 events per year in the 2010s. Bangladesh is among the most flood-prone countries globally due to its delta geography.",
+    "context_docs": ["EM-DAT flood events Bangladesh 1990-2021", "EOSDIS flood records South Asia"],
+    "verification_sources": ["EM-DAT", "Wikipedia: Floods in Bangladesh"]
+  },
+  {
+    "id": "gd-002",
+    "question": "How many earthquake disasters occurred in Asia between 2000 and 2020?",
+    "ground_truth": "Asia recorded hundreds of significant earthquake disasters between 2000 and 2020 per EM-DAT. The region is seismically the most active in the world, with major events including the 2004 Indian Ocean earthquake (Mw 9.1), the 2008 Sichuan earthquake (Mw 7.9), the 2011 Tōhoku earthquake (Mw 9.0), and the 2015 Nepal earthquake (Mw 7.8).",
+    "context_docs": ["EM-DAT earthquake events Asia 2000-2020", "USGS earthquake catalog Asia"],
+    "verification_sources": ["EM-DAT", "USGS Earthquake Hazards Program"]
+  },
+  {
+    "id": "gd-003",
+    "question": "Which year had the most recorded natural disaster deaths globally in the 21st century?",
+    "ground_truth": "2004 was among the deadliest years for natural disasters in the 21st century, primarily due to the Indian Ocean tsunami on December 26 which killed over 227,000 people across 14 countries. Other extremely deadly years include 2008 (Cyclone Nargis + Sichuan earthquake) and 2010 (Haiti earthquake, which killed over 220,000 people).",
+    "context_docs": ["EM-DAT annual disaster statistics 2000-2021", "OFDA/CRED global disaster data"],
+    "verification_sources": ["EM-DAT", "Wikipedia: List of deadliest natural disasters"]
+  },
+  {
+    "id": "gd-004",
+    "question": "How many tropical storm events hit the Caribbean region between 1990 and 2010?",
+    "ground_truth": "The Caribbean experienced dozens of significant tropical storms and hurricanes between 1990 and 2010. Notable events include Hurricane Georges (1998), Hurricane Mitch (1998, killed ~11,000), Hurricane Ivan (2004), Hurricane Katrina (2005, affected Caribbean before hitting the US), and Hurricane Dean (2007). The Atlantic hurricane season produces an average of 12 named storms per year.",
+    "context_docs": ["NOAA Atlantic hurricane records 1990-2010", "EM-DAT storm events Caribbean"],
+    "verification_sources": ["NOAA National Hurricane Center", "EM-DAT"]
+  },
+  {
+    "id": "gd-005",
+    "question": "How many drought events were recorded in Africa during the 2000s?",
+    "ground_truth": "Africa recorded numerous significant drought events during the 2000s per EM-DAT. Major droughts affected the Sahel, Horn of Africa (particularly 2002-2003 and 2005-2006), and Southern Africa. The 2002-2003 southern African drought affected over 14 million people across multiple countries. Africa consistently accounts for the highest number of drought-affected people globally.",
+    "context_docs": ["EM-DAT drought events Africa 2000-2009", "FEWS NET drought records Africa"],
+    "verification_sources": ["EM-DAT", "FAO drought assessments Africa"]
+  },
+  {
+    "id": "gd-006",
+    "question": "How many volcanic eruptions were recorded globally since 1990 that caused casualties?",
+    "ground_truth": "Since 1990, dozens of volcanic eruptions have caused casualties globally according to EM-DAT and the Smithsonian Global Volcanism Program. Major deadly eruptions include Pinatubo (1991, Philippines, ~800 deaths), Ruapehu (1996, New Zealand), Merapi (2010, Indonesia, ~350 deaths), and Ontake (2014, Japan, 57 deaths). Indonesia, Philippines, and Japan account for the majority of deadly eruptions.",
+    "context_docs": ["EM-DAT volcanic eruption records 1990-2023", "Smithsonian Global Volcanism Program"],
+    "verification_sources": ["EM-DAT", "Smithsonian Global Volcanism Program"]
+  },
+  {
+    "id": "gd-007",
+    "question": "What was the deadliest earthquake of the 21st century in terms of fatalities?",
+    "ground_truth": "The 2010 Haiti earthquake (magnitude 7.0, January 12) is the deadliest earthquake of the 21st century, killing an estimated 220,000–316,000 people. It struck near Port-au-Prince. The second deadliest was the 2004 Indian Ocean earthquake and tsunami (magnitude 9.1) which caused over 227,000 deaths across 14 countries.",
+    "context_docs": ["EM-DAT earthquake deaths 2000-2021", "USGS earthquake catalog"],
+    "verification_sources": ["EM-DAT", "USGS", "Wikipedia: 2010 Haiti earthquake"]
+  },
+  {
+    "id": "gd-008",
+    "question": "How many people were killed by the 2004 Indian Ocean tsunami?",
+    "ground_truth": "The 2004 Indian Ocean tsunami (triggered by a magnitude 9.1 earthquake off the coast of Sumatra on December 26) killed approximately 227,898 people across 14 countries. Indonesia suffered the most deaths (~167,000), followed by Sri Lanka (~35,000), India (~12,400), and Thailand (~5,400). It is the deadliest tsunami in recorded history.",
+    "context_docs": ["EM-DAT 2004 Indian Ocean disaster", "USGS 2004 Sumatra earthquake"],
+    "verification_sources": ["EM-DAT", "USGS", "Wikipedia: 2004 Indian Ocean earthquake and tsunami"]
+  },
+  {
+    "id": "gd-009",
+    "question": "What disaster caused the highest death toll in Haiti's recorded history?",
+    "ground_truth": "The 2010 Haiti earthquake (January 12, magnitude 7.0) caused the highest death toll in Haiti's history, killing an estimated 220,000 to 316,000 people. It also injured approximately 300,000, displaced 1.5 million, and caused around $8 billion in economic damage. The earthquake struck near Port-au-Prince and was devastating due to poor building construction and high urban density.",
+    "context_docs": ["EM-DAT Haiti disaster history", "USGS 2010 Haiti earthquake"],
+    "verification_sources": ["EM-DAT", "Wikipedia: 2010 Haiti earthquake", "World Bank Haiti"]
+  },
+  {
+    "id": "gd-010",
+    "question": "How many people were killed by Hurricane Katrina in 2005?",
+    "ground_truth": "Hurricane Katrina caused approximately 1,833 direct deaths in the United States in August–September 2005, making it the deadliest Atlantic hurricane since 1928. The majority of deaths occurred in Louisiana (1,577), particularly in New Orleans where levee failures caused catastrophic flooding. It also caused about $125 billion in economic damage, making it one of the costliest natural disasters in US history.",
+    "context_docs": ["NOAA Hurricane Katrina 2005 data", "EM-DAT storm USA 2005"],
+    "verification_sources": ["NOAA National Hurricane Center", "EM-DAT", "Wikipedia: Hurricane Katrina"]
+  },
+  {
+    "id": "gd-011",
+    "question": "What was the death toll from the 1998 Bangladesh floods?",
+    "ground_truth": "The 1998 Bangladesh floods were among the worst in the country's history, lasting from July to September and submerging about two-thirds of the country. The floods killed approximately 1,000–1,100 people directly and left about 30 million people homeless. Economic damage was estimated at nearly $6 billion. The disaster prompted major flood management investments in Bangladesh.",
+    "context_docs": ["EM-DAT Bangladesh flood 1998", "EOSDIS 1998 Bangladesh flood"],
+    "verification_sources": ["EM-DAT", "Wikipedia: 1998 Bangladesh floods", "ReliefWeb"]
+  },
+  {
+    "id": "gd-012",
+    "question": "How many people died in the 2008 Sichuan earthquake in China?",
+    "ground_truth": "The 2008 Sichuan earthquake (magnitude 7.9, May 12) killed approximately 69,197 people, with 374,171 injured and 18,222 missing. It was the deadliest earthquake in China since the 1976 Tangshan earthquake. The disaster caused an estimated $85 billion in economic damage. School collapses drew international criticism, contributing to subsequent building code reforms in China.",
+    "context_docs": ["EM-DAT China earthquake 2008", "USGS 2008 Sichuan earthquake"],
+    "verification_sources": ["EM-DAT", "USGS", "Wikipedia: 2008 Sichuan earthquake"]
+  },
+  {
+    "id": "gd-013",
+    "question": "What was the most economically damaging storm in US history?",
+    "ground_truth": "Hurricane Katrina (2005) is generally considered the most economically damaging storm in US history, causing approximately $125 billion in damage (2005 USD), or over $180 billion in 2023 dollars. Hurricane Harvey (2017) is close behind with ~$125 billion in damage. Other extremely costly storms include Hurricane Maria (2017, ~$90 billion) and Hurricane Sandy (2012, ~$65 billion).",
+    "context_docs": ["NOAA US billion-dollar disaster database", "EM-DAT storm USA economic damage"],
+    "verification_sources": ["NOAA NCEI Billion-Dollar Disasters", "EM-DAT"]
+  },
+  {
+    "id": "gd-014",
+    "question": "How much economic damage did the 2011 Japan earthquake and tsunami cause?",
+    "ground_truth": "The 2011 Tōhoku earthquake and tsunami (March 11, magnitude 9.0) caused approximately $235 billion in economic damage, making it the costliest natural disaster in history at the time. The World Bank estimated reconstruction costs at $235 billion. The event killed approximately 15,899 people and triggered the Fukushima Daiichi nuclear disaster.",
+    "context_docs": ["EM-DAT Japan earthquake tsunami 2011", "World Bank Japan disaster assessment 2011"],
+    "verification_sources": ["EM-DAT", "World Bank", "Wikipedia: 2011 Tōhoku earthquake"]
+  },
+  {
+    "id": "gd-015",
+    "question": "What was the total economic damage from floods globally in the 2010s?",
+    "ground_truth": "Global flood damage totaled hundreds of billions of dollars during the 2010s. The 2011 Thailand floods alone caused approximately $40 billion in damage. NOAA and Munich Re data suggest global flood losses averaged over $40 billion per year during the 2010s. Asia (particularly China, India, and Thailand) accounted for the majority of flood economic losses during this period.",
+    "context_docs": ["EM-DAT global flood economic damage 2010-2019", "Munich Re NatCat flood data 2010s"],
+    "verification_sources": ["EM-DAT", "Munich Re NatCatSERVICE", "Swiss Re sigma report"]
+  },
+  {
+    "id": "gd-016",
+    "question": "How does economic damage from storms compare to floods in North America?",
+    "ground_truth": "In North America, storms (hurricanes, tornadoes, severe thunderstorms) typically cause far more economic damage than floods. NOAA data shows storms account for roughly 70-80% of total natural disaster economic losses in the US, while floods account for 10-15%. Hurricanes like Katrina ($125B), Harvey ($125B), and Maria ($90B) dwarf individual flood events in economic impact.",
+    "context_docs": ["NOAA billion-dollar disaster types USA", "EM-DAT storm vs flood North America"],
+    "verification_sources": ["NOAA NCEI Billion-Dollar Disasters", "EM-DAT"]
+  },
+  {
+    "id": "gd-017",
+    "question": "Which country suffered the most economic damage from natural disasters in the 2000s?",
+    "ground_truth": "The United States suffered the most absolute economic damage from natural disasters in the 2000s, primarily from Hurricane Katrina (2005, ~$125B) and other major storms. However, relative to GDP, developing nations fared worse. China also experienced enormous losses from the 2008 Sichuan earthquake (~$85B). Japan, Haiti, and Indonesia also suffered catastrophic losses relative to their economies.",
+    "context_docs": ["EM-DAT economic damage by country 2000-2009", "Munich Re disaster economics 2000s"],
+    "verification_sources": ["EM-DAT", "Munich Re NatCatSERVICE", "Swiss Re"]
+  },
+  {
+    "id": "gd-018",
+    "question": "What was the economic impact of the 2010 Haiti earthquake?",
+    "ground_truth": "The 2010 Haiti earthquake caused approximately $7.8–$8 billion in economic damage, equivalent to over 100% of Haiti's GDP at the time. The World Bank estimated reconstruction needs at $11.5 billion. Port-au-Prince's infrastructure was devastated, including government buildings, hospitals, and over 100,000 homes. Haiti received roughly $13 billion in international aid pledges for reconstruction.",
+    "context_docs": ["EM-DAT Haiti earthquake 2010 economic impact", "World Bank Haiti post-disaster assessment"],
+    "verification_sources": ["EM-DAT", "World Bank", "Wikipedia: 2010 Haiti earthquake"]
+  },
+  {
+    "id": "gd-019",
+    "question": "Which disaster type causes more average deaths per event: earthquakes or storms?",
+    "ground_truth": "Earthquakes historically cause more deaths per event than storms on average, primarily because major earthquakes strike without warning and can cause catastrophic building collapse. EM-DAT data shows earthquakes average thousands of deaths per significant event (e.g., 2010 Haiti ~220,000; 2004 Indian Ocean ~228,000). Storms cause more deaths in aggregate annually but are more survivable individually, especially in countries with early warning systems.",
+    "context_docs": ["EM-DAT deaths by disaster type comparison", "CRED disaster statistics mortality"],
+    "verification_sources": ["EM-DAT / CRED", "UNDRR Global Assessment Report"]
+  },
+  {
+    "id": "gd-020",
+    "question": "How do floods compare to droughts in terms of people affected globally?",
+    "ground_truth": "Droughts affect far more people globally than floods in terms of total affected population. EM-DAT data shows droughts affect hundreds of millions annually, particularly in Africa and Asia, because they impact large agricultural areas over extended periods. Floods, while causing more deaths and economic damage, typically affect smaller geographic areas. Droughts accounted for roughly 35-40% of all disaster-affected people globally in the 2000s-2010s.",
+    "context_docs": ["EM-DAT affected population floods vs droughts", "CRED disaster type statistics"],
+    "verification_sources": ["EM-DAT", "CRED", "UNDRR Global Assessment Report"]
+  },
+  {
+    "id": "gd-021",
+    "question": "Which disaster type is most common in Southeast Asia?",
+    "ground_truth": "Floods are the most common disaster type in Southeast Asia by event count, according to EM-DAT. The region's monsoon climate, low-lying deltas (Mekong, Irrawaddy, Chao Phraya), and dense coastal populations make flooding the dominant hazard. Storms (tropical cyclones) are the second most frequent and most deadly disaster type. The Philippines, Vietnam, Indonesia, and Bangladesh are among the most disaster-affected countries in the region.",
+    "context_docs": ["EM-DAT Southeast Asia disaster types", "UNDRR Asia Pacific disaster data"],
+    "verification_sources": ["EM-DAT", "UNDRR", "ESCAP Disaster Statistics"]
+  },
+  {
+    "id": "gd-022",
+    "question": "Are wildfires or storms more frequent in North America?",
+    "ground_truth": "Storms are significantly more frequent than wildfires as recorded disaster events in North America. NOAA data shows the US alone averages 10–15 billion-dollar storm events per year, while wildfires average 1–3. However, wildfire frequency has increased dramatically since 2010 in western North America due to drought and climate change. The 2017-2020 California wildfire seasons were record-breaking, with 2020 burning over 4 million acres.",
+    "context_docs": ["NOAA US disaster frequency storms vs wildfires", "EM-DAT North America wildfire storm events"],
+    "verification_sources": ["NOAA NCEI Billion-Dollar Disasters", "Cal Fire statistics", "EM-DAT"]
+  },
+  {
+    "id": "gd-023",
+    "question": "How do earthquake mortality rates differ between developed and developing countries?",
+    "ground_truth": "Earthquake mortality rates are dramatically higher in developing countries than in developed ones for comparable-magnitude events. The 2010 Haiti earthquake (M7.0) killed ~220,000 people; a similar-magnitude event in California (e.g., 1989 Loma Prieta, M6.9) killed 63. This disparity reflects building construction quality, enforcement of seismic codes, emergency response capacity, and healthcare infrastructure. Japan's M9.0 2011 earthquake caused ~15,900 deaths; a similar event in an unprep country could cause millions.",
+    "context_docs": ["EM-DAT earthquake mortality developed vs developing", "USGS seismic risk global comparison"],
+    "verification_sources": ["EM-DAT", "USGS", "World Bank seismic risk report"]
+  },
+  {
+    "id": "gd-024",
+    "question": "Which region experiences the most earthquake events globally?",
+    "ground_truth": "The Asia-Pacific region (including the Ring of Fire countries: Japan, Indonesia, Philippines, China, New Zealand) experiences the most earthquake events globally by frequency and total energy released. Indonesia and Japan are the most earthquake-prone countries. The Ring of Fire accounts for approximately 90% of the world's earthquakes and about 80% of the world's largest earthquakes. Chile, Peru, and the western US also experience high seismic activity.",
+    "context_docs": ["USGS global earthquake frequency by region", "EM-DAT earthquake events by region"],
+    "verification_sources": ["USGS Earthquake Hazards Program", "EM-DAT", "British Geological Survey"]
+  },
+  {
+    "id": "gd-025",
+    "question": "Has the frequency of natural disasters increased since 1990?",
+    "ground_truth": "Recorded natural disaster events increased substantially from 1990 to approximately 2005, then plateaued and slightly declined in reported events. EM-DAT data shows recorded disasters rose from ~200/year in 1990 to a peak of ~450/year around 2000–2005, partly reflecting improved reporting. Climate-sensitive disasters (floods, storms, extreme temperatures) have increased in frequency, while geological disasters (earthquakes, volcanoes) show no long-term trend.",
+    "context_docs": ["EM-DAT disaster frequency 1990-2021 annual statistics", "CRED disaster trends report"],
+    "verification_sources": ["EM-DAT", "CRED", "UNDRR Global Assessment Report 2022"]
+  },
+  {
+    "id": "gd-026",
+    "question": "Are storm intensities increasing over time due to climate change?",
+    "ground_truth": "Scientific consensus indicates that while total storm frequency may not be increasing significantly, the proportion of high-intensity storms (Category 4–5 hurricanes) is increasing due to warmer ocean temperatures. The 2021 IPCC AR6 report states with high confidence that the proportion of intense tropical cyclones and associated heavy precipitation have increased globally since the 1980s. Economic losses from storms have grown significantly due to both increased intensity and coastal development.",
+    "context_docs": ["NOAA historical hurricane intensity trends", "EM-DAT storm damage trends 1990-2021"],
+    "verification_sources": ["IPCC AR6 2021", "NOAA National Hurricane Center", "Nature Climate Change studies"]
+  },
+  {
+    "id": "gd-027",
+    "question": "How has flood frequency in South Asia changed over the past 30 years?",
+    "ground_truth": "Flood frequency and severity in South Asia has increased significantly over the past 30 years. EM-DAT data shows India, Bangladesh, and Pakistan report increasing numbers of significant flood events annually. The 2022 Pakistan super-floods affected one-third of the country (33 million people). Attribution studies link increased monsoon intensity to climate change. Bangladesh flood frequency roughly doubled between the 1990s and 2010s.",
+    "context_docs": ["EM-DAT South Asia flood frequency 1990-2022", "EOSDIS flood events India Bangladesh Pakistan"],
+    "verification_sources": ["EM-DAT", "ReliefWeb", "IPCC AR6 Chapter 11"]
+  },
+  {
+    "id": "gd-028",
+    "question": "What trends exist in disaster-related deaths over the past two decades?",
+    "ground_truth": "Disaster-related deaths show a declining long-term trend over the past two decades despite increasing event frequency, reflecting improved early warning systems, disaster preparedness, and resilience investments. EM-DAT data shows average annual deaths declined from ~100,000/year in the 1990s to ~60,000/year in the 2010s (excluding outlier years like 2004 and 2010). However, heat-related deaths are increasing, and climate impacts are projected to reverse these gains.",
+    "context_docs": ["EM-DAT global annual disaster deaths 2000-2021", "CRED disaster statistics mortality trends"],
+    "verification_sources": ["EM-DAT", "CRED", "UNDRR Global Assessment Report 2022"]
+  },
+  {
+    "id": "gd-029",
+    "question": "How has economic damage from natural disasters changed over the past 30 years?",
+    "ground_truth": "Economic losses from natural disasters have increased substantially over the past 30 years. Munich Re and Swiss Re data show global insured losses grew from an average of ~$50 billion/year in the 1990s to ~$100 billion/year in the 2010s (2023 USD). Total economic losses (insured + uninsured) roughly tripled over this period. Drivers include increased disaster intensity (climate change), rapid urbanization in risk zones, and rising asset values — not just increased reporting.",
+    "context_docs": ["EM-DAT global economic damage trend 1990-2021", "Munich Re NatCat annual report"],
+    "verification_sources": ["Munich Re NatCatSERVICE", "Swiss Re sigma", "EM-DAT"]
+  },
+  {
+    "id": "gd-030",
+    "question": "Are drought events becoming more frequent and severe in Africa?",
+    "ground_truth": "Yes, drought frequency and severity is increasing in parts of Africa, particularly in the Horn of Africa and southern Africa. The 2011 Horn of Africa drought was the worst in 60 years, affecting 13 million people. The 2022 Horn of Africa drought (5th consecutive failed rainy season) was declared the worst in 40 years. The IPCC AR6 projects higher drought frequency and intensity across most of Africa under all warming scenarios, with the southern Africa and Sahel regions most at risk.",
+    "context_docs": ["EM-DAT Africa drought events 1990-2022", "FEWS NET drought severity Africa"],
+    "verification_sources": ["EM-DAT", "FEWS NET", "IPCC AR6 Chapter 9 (Africa)"]
+  }
+]

--- a/ai-architect/terra-query/terra-mcp/eval/ragas_evaluator.py
+++ b/ai-architect/terra-query/terra-mcp/eval/ragas_evaluator.py
@@ -1,0 +1,173 @@
+"""RAGAS-based evaluation: Context Precision, Context Recall, Faithfulness, Answer Relevance.
+
+Cross-provider design:
+  Generator: OpenAI gpt-4o-mini  (produces answers)
+  Evaluator: Anthropic claude-haiku  (scores answers — avoids self-eval bias)
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from eval.answer_generator import EvalSample
+from eval.eval_config import EvalConfig, EvalThresholds
+
+logger = logging.getLogger(__name__)
+
+METRIC_NAMES = ("context_precision", "context_recall", "faithfulness", "answer_relevance")
+
+
+@dataclass
+class MetricScore:
+    name: str
+    score: float
+    threshold: float
+    min_threshold: float
+
+    @property
+    def passes(self) -> bool:
+        return self.score >= self.threshold
+
+    @property
+    def above_minimum(self) -> bool:
+        return self.score >= self.min_threshold
+
+    @property
+    def status(self) -> str:
+        if self.passes:
+            return "PASS"
+        if self.above_minimum:
+            return "WARN"
+        return "FAIL"
+
+
+@dataclass
+class EvalResult:
+    metric_scores: list[MetricScore]
+    sample_count: int
+
+    @property
+    def all_pass(self) -> bool:
+        return all(m.passes for m in self.metric_scores)
+
+    @property
+    def above_minimum(self) -> bool:
+        return all(m.above_minimum for m in self.metric_scores)
+
+    @property
+    def any_hard_fail(self) -> bool:
+        return any(not m.above_minimum for m in self.metric_scores)
+
+    def to_summary(self) -> str:
+        lines = [f"=== TerraQuery RAGAS Evaluation ({self.sample_count} samples) ==="]
+        for m in self.metric_scores:
+            lines.append(
+                f"  [{m.status}] {m.name:<22} {m.score:.3f}  "
+                f"(target≥{m.threshold:.2f}, min≥{m.min_threshold:.2f})"
+            )
+        overall = "ALL PASS" if self.all_pass else ("WARN" if self.above_minimum else "HARD FAIL")
+        lines.append(f"\nOverall: {overall}")
+        return "\n".join(lines)
+
+    def to_github_summary(self) -> str:
+        """Markdown table for GitHub Actions job summary."""
+        rows = ["| Metric | Score | Target | Min | Status |", "|--------|-------|--------|-----|--------|"]
+        for m in self.metric_scores:
+            icon = "✅" if m.passes else ("⚠️" if m.above_minimum else "❌")
+            rows.append(
+                f"| {m.name} | {m.score:.3f} | ≥{m.threshold:.2f} | ≥{m.min_threshold:.2f} | {icon} {m.status} |"
+            )
+        rows.append(f"\n**Samples evaluated:** {self.sample_count}")
+        return "\n".join(rows)
+
+
+class RagasEvaluator:
+    """Runs RAGAS evaluation on a list of EvalSamples.
+
+    Metrics used (all scored by evaluator LLM = Anthropic claude-haiku):
+      - LLMContextPrecisionWithReference: fraction of retrieved context relevant to answer
+      - LLMContextRecall: fraction of ground-truth supported by retrieved context
+      - Faithfulness: answer grounded in retrieved context (no hallucination)
+      - ResponseRelevancy: answer addresses the question
+    """
+
+    def __init__(self, config: EvalConfig) -> None:
+        self._config = config
+
+    def evaluate(self, samples: list[EvalSample]) -> EvalResult:
+        if not samples:
+            raise ValueError("Cannot evaluate an empty sample list")
+        ragas_samples = self._to_ragas_samples(samples)
+        scores = self._run_ragas(ragas_samples)
+        return self._build_result(scores, len(samples))
+
+    def _to_ragas_samples(self, samples: list[EvalSample]):
+        from ragas.dataset_schema import SingleTurnSample
+
+        return [
+            SingleTurnSample(
+                user_input=s.question,
+                retrieved_contexts=s.contexts if s.contexts else [""],
+                response=s.answer,
+                reference=s.ground_truth,
+            )
+            for s in samples
+        ]
+
+    def _run_ragas(self, ragas_samples) -> dict[str, float]:
+        from ragas import evaluate, EvaluationDataset
+        from ragas.llms import LangchainLLMWrapper
+        from ragas.embeddings import LangchainEmbeddingsWrapper
+        from ragas.metrics import (
+            LLMContextPrecisionWithReference,
+            LLMContextRecall,
+            Faithfulness,
+            ResponseRelevancy,
+        )
+        from langchain_openai import ChatOpenAI, OpenAIEmbeddings
+        from langchain_anthropic import ChatAnthropic
+
+        evaluator_llm = LangchainLLMWrapper(
+            ChatAnthropic(
+                model=self._config.evaluator_model,
+                api_key=self._config.anthropic_api_key,
+                temperature=0,
+            )
+        )
+        generator_embeddings = LangchainEmbeddingsWrapper(
+            OpenAIEmbeddings(
+                model="text-embedding-3-small",
+                api_key=self._config.openai_api_key,
+            )
+        )
+
+        metrics = [
+            LLMContextPrecisionWithReference(llm=evaluator_llm),
+            LLMContextRecall(llm=evaluator_llm),
+            Faithfulness(llm=evaluator_llm),
+            ResponseRelevancy(llm=evaluator_llm, embeddings=generator_embeddings),
+        ]
+
+        dataset = EvaluationDataset(samples=ragas_samples)
+        result = evaluate(dataset=dataset, metrics=metrics)
+        df = result.to_pandas()
+
+        return {
+            "context_precision": float(df["context_precision"].mean()),
+            "context_recall": float(df["context_recall"].mean()),
+            "faithfulness": float(df["faithfulness"].mean()),
+            "answer_relevance": float(df["answer_relevancy"].mean()),
+        }
+
+    def _build_result(self, scores: dict[str, float], sample_count: int) -> EvalResult:
+        t: EvalThresholds = self._config.thresholds
+        metric_scores = [
+            MetricScore(
+                name=name,
+                score=scores[name],
+                threshold=t.target_for(name),
+                min_threshold=t.min_for(name),
+            )
+            for name in METRIC_NAMES
+        ]
+        return EvalResult(metric_scores=metric_scores, sample_count=sample_count)

--- a/ai-architect/terra-query/terra-mcp/requirements-eval.txt
+++ b/ai-architect/terra-query/terra-mcp/requirements-eval.txt
@@ -1,0 +1,6 @@
+-r requirements.txt
+ragas>=0.2.0
+langchain-openai>=0.1.0
+langchain-anthropic>=0.1.0
+openai>=1.0.0
+anthropic>=0.20.0

--- a/ai-architect/terra-query/terra-mcp/tests/eval/test_answer_generator.py
+++ b/ai-architect/terra-query/terra-mcp/tests/eval/test_answer_generator.py
@@ -1,0 +1,174 @@
+"""Unit tests for AnswerGenerator and McpDirectRetriever."""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from eval.answer_generator import AnswerGenerator, EvalSample, McpDirectRetriever, _row_to_context
+
+
+class TestMcpDirectRetriever:
+    @pytest.fixture()
+    def engine_with_results(self):
+        engine = MagicMock()
+        engine.search.return_value = [
+            {"record_id": "eosdis_1", "score": 0.90, "text": "Earthquake in Indonesia 2004"},
+            {"record_id": "eosdis_3", "score": 0.75, "text": "Earthquake in Haiti 2010"},
+        ]
+        return engine
+
+    @pytest.fixture()
+    def small_repo(self, sample_df):
+        repo = MagicMock()
+        repo.df = sample_df
+        return repo
+
+    def test_retrieve_returns_context_strings(self, small_repo, engine_with_results):
+        retriever = McpDirectRetriever(small_repo, engine_with_results, top_k=2)
+        contexts = retriever.retrieve("earthquake deaths Asia")
+        assert len(contexts) == 2
+        assert all(isinstance(c, str) for c in contexts)
+        assert all(len(c) > 10 for c in contexts)
+
+    def test_retrieve_no_engine_returns_empty(self, small_repo):
+        retriever = McpDirectRetriever(small_repo, None, top_k=5)
+        contexts = retriever.retrieve("any query")
+        assert contexts == []
+
+    def test_retrieve_respects_top_k(self, small_repo, engine_with_results):
+        engine_with_results.search.return_value = [
+            {"record_id": f"rec_{i}", "score": 0.9 - i * 0.1, "text": f"Event {i}"}
+            for i in range(10)
+        ]
+        retriever = McpDirectRetriever(small_repo, engine_with_results, top_k=3)
+        contexts = retriever.retrieve("floods")
+        assert len(contexts) <= 3
+
+    def test_retrieve_falls_back_to_text_when_no_row_match(self, small_repo, engine_with_results):
+        engine_with_results.search.return_value = [
+            {"record_id": "nonexistent_999", "score": 0.80, "text": "Some fallback text"},
+        ]
+        retriever = McpDirectRetriever(small_repo, engine_with_results, top_k=5)
+        contexts = retriever.retrieve("storms")
+        assert any("fallback" in c or "Some" in c for c in contexts)
+
+    def test_retrieve_context_contains_country(self, small_repo, engine_with_results):
+        retriever = McpDirectRetriever(small_repo, engine_with_results, top_k=2)
+        contexts = retriever.retrieve("earthquake")
+        assert any("Indonesia" in c or "Haiti" in c for c in contexts)
+
+
+class TestRowToContext:
+    def test_basic_row(self):
+        row = {
+            "disaster_type": "flood",
+            "country": "Bangladesh",
+            "region": "Southern Asia",
+            "start_date": pd.Timestamp("1998-07-01"),
+            "deaths": 1050.0,
+            "economic_damage_usd": 5_900_000_000.0,
+            "affected": 30_000_000.0,
+            "magnitude": None,
+        }
+        text = _row_to_context(row)
+        assert "Flood" in text
+        assert "Bangladesh" in text
+        assert "1998" in text
+        assert "1050" in text or "deaths" in text
+
+    def test_na_fields_show_unknown(self):
+        row = {
+            "disaster_type": "drought",
+            "country": "Zimbabwe",
+            "region": "Eastern Africa",
+            "start_date": pd.Timestamp("2020-01-01"),
+            "deaths": pd.NA,
+            "economic_damage_usd": pd.NA,
+            "affected": 5_700_000.0,
+            "magnitude": None,
+        }
+        text = _row_to_context(row)
+        assert "unknown" in text.lower()
+        assert "Zimbabwe" in text
+
+
+class TestAnswerGenerator:
+    @pytest.fixture()
+    def mock_retriever(self):
+        retriever = MagicMock()
+        retriever.retrieve.return_value = [
+            "Flood in Bangladesh 1998. Deaths: 1050. Affected: 30,000,000.",
+            "Bangladesh flood frequency doubled in 2010s vs 1990s.",
+        ]
+        return retriever
+
+    @pytest.fixture()
+    def mock_generator_fn(self):
+        return lambda prompt: "Bangladesh has experienced many flood disasters historically."
+
+    def test_generate_sample_returns_eval_sample(self, mock_retriever, mock_generator_fn):
+        gen = AnswerGenerator(mock_retriever, mock_generator_fn)
+        sample = gen.generate_sample("gd-001", "How many floods in Bangladesh?", "Over 100 floods.")
+        assert isinstance(sample, EvalSample)
+        assert sample.question_id == "gd-001"
+        assert sample.question == "How many floods in Bangladesh?"
+        assert sample.ground_truth == "Over 100 floods."
+        assert len(sample.contexts) == 2
+        assert "Bangladesh" in sample.answer
+
+    def test_generate_sample_empty_contexts_returns_fallback_answer(self, mock_generator_fn):
+        retriever = MagicMock()
+        retriever.retrieve.return_value = []
+        gen = AnswerGenerator(retriever, mock_generator_fn)
+        sample = gen.generate_sample("gd-001", "What happened?", "Something happened.")
+        assert "Insufficient" in sample.answer or sample.answer != ""
+
+    def test_generate_sample_prompt_includes_question(self, mock_generator_fn):
+        captured = []
+
+        def capture_fn(prompt: str) -> str:
+            captured.append(prompt)
+            return "answer"
+
+        retriever = MagicMock()
+        retriever.retrieve.return_value = ["some context"]
+        gen = AnswerGenerator(retriever, capture_fn)
+        gen.generate_sample("gd-001", "How many floods?", "ground truth")
+        assert len(captured) == 1
+        assert "How many floods?" in captured[0]
+        assert "some context" in captured[0]
+
+    def test_generate_batch_processes_all_entries(self, mock_retriever, mock_generator_fn):
+        gen = AnswerGenerator(mock_retriever, mock_generator_fn)
+        entries = [
+            {"id": f"gd-{i:03d}", "question": f"Q{i}", "ground_truth": f"GT{i}"}
+            for i in range(1, 4)
+        ]
+        samples = gen.generate_batch(entries)
+        assert len(samples) == 3
+        assert [s.question_id for s in samples] == ["gd-001", "gd-002", "gd-003"]
+
+    def test_generate_batch_skips_failing_entries(self, mock_generator_fn):
+        call_count = 0
+
+        def failing_retriever_retrieve(question):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise RuntimeError("Simulated retrieval error")
+            return ["context"]
+
+        retriever = MagicMock()
+        retriever.retrieve.side_effect = failing_retriever_retrieve
+        gen = AnswerGenerator(retriever, mock_generator_fn)
+        entries = [
+            {"id": "gd-001", "question": "Q1", "ground_truth": "GT1"},
+            {"id": "gd-002", "question": "Q2", "ground_truth": "GT2"},
+            {"id": "gd-003", "question": "Q3", "ground_truth": "GT3"},
+        ]
+        samples = gen.generate_batch(entries)
+        assert len(samples) == 2  # gd-002 skipped

--- a/ai-architect/terra-query/terra-mcp/tests/eval/test_eval_config.py
+++ b/ai-architect/terra-query/terra-mcp/tests/eval/test_eval_config.py
@@ -1,0 +1,88 @@
+"""Unit tests for EvalConfig and EvalThresholds."""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from eval.eval_config import EvalConfig, EvalThresholds
+
+
+class TestEvalThresholds:
+    def test_defaults(self):
+        t = EvalThresholds()
+        assert t.context_precision == 0.80
+        assert t.context_recall == 0.75
+        assert t.faithfulness == 0.85
+        assert t.answer_relevance == 0.80
+
+    def test_min_thresholds_are_ten_below_target(self):
+        t = EvalThresholds()
+        assert t.context_precision_min == pytest.approx(0.70)
+        assert t.context_recall_min == pytest.approx(0.65)
+        assert t.faithfulness_min == pytest.approx(0.75)
+        assert t.answer_relevance_min == pytest.approx(0.70)
+
+    def test_target_for_helper(self):
+        t = EvalThresholds()
+        assert t.target_for("context_precision") == 0.80
+        assert t.target_for("faithfulness") == 0.85
+
+    def test_min_for_helper(self):
+        t = EvalThresholds()
+        assert t.min_for("context_recall") == pytest.approx(0.65)
+        assert t.min_for("answer_relevance") == pytest.approx(0.70)
+
+    def test_custom_thresholds(self):
+        t = EvalThresholds(context_precision=0.90, faithfulness=0.95)
+        assert t.context_precision == 0.90
+        assert t.context_precision_min == pytest.approx(0.80)
+        assert t.faithfulness_min == pytest.approx(0.85)
+
+    def test_frozen_immutability(self):
+        t = EvalThresholds()
+        with pytest.raises((AttributeError, TypeError)):
+            t.context_precision = 0.99  # type: ignore[misc]
+
+
+class TestEvalConfig:
+    def test_defaults(self):
+        cfg = EvalConfig(openai_api_key="sk-test", anthropic_api_key="ant-test")
+        assert cfg.generator_model == "gpt-4o-mini"
+        assert cfg.evaluator_model == "claude-haiku-4-5-20251001"
+        assert cfg.canary_size == 10
+        assert cfg.full_size == 30
+        assert cfg.top_k_contexts == 5
+
+    def test_from_env_reads_api_keys(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-env-key")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "ant-env-key")
+        cfg = EvalConfig.from_env()
+        assert cfg.openai_api_key == "sk-env-key"
+        assert cfg.anthropic_api_key == "ant-env-key"
+
+    def test_from_env_missing_keys_returns_empty_strings(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        cfg = EvalConfig.from_env()
+        assert cfg.openai_api_key == ""
+        assert cfg.anthropic_api_key == ""
+
+    def test_validate_passes_with_keys(self):
+        cfg = EvalConfig(openai_api_key="sk-test", anthropic_api_key="ant-test")
+        cfg.validate()  # should not raise
+
+    def test_validate_raises_on_missing_openai_key(self):
+        cfg = EvalConfig(openai_api_key="", anthropic_api_key="ant-test")
+        with pytest.raises(ValueError, match="OPENAI_API_KEY"):
+            cfg.validate()
+
+    def test_validate_raises_on_missing_anthropic_key(self):
+        cfg = EvalConfig(openai_api_key="sk-test", anthropic_api_key="")
+        with pytest.raises(ValueError, match="ANTHROPIC_API_KEY"):
+            cfg.validate()
+
+    def test_threshold_defaults_propagated(self):
+        cfg = EvalConfig()
+        assert cfg.thresholds.faithfulness == 0.85

--- a/ai-architect/terra-query/terra-mcp/tests/eval/test_ragas_evaluator.py
+++ b/ai-architect/terra-query/terra-mcp/tests/eval/test_ragas_evaluator.py
@@ -1,0 +1,211 @@
+"""Unit tests for RagasEvaluator, MetricScore, and EvalResult."""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from eval.answer_generator import EvalSample
+from eval.eval_config import EvalConfig, EvalThresholds
+from eval.ragas_evaluator import EvalResult, MetricScore, RagasEvaluator
+
+
+def _make_sample(qid: str = "gd-001") -> EvalSample:
+    return EvalSample(
+        question_id=qid,
+        question="How many flood events occurred in Bangladesh?",
+        ground_truth="Over 100 floods between 1990 and 2021.",
+        contexts=["Bangladesh flood 1998: 1050 deaths.", "Flood frequency doubled in 2010s."],
+        answer="Bangladesh experienced over 100 flood events between 1990 and 2021.",
+    )
+
+
+def _make_config(**overrides) -> EvalConfig:
+    defaults = dict(openai_api_key="sk-test", anthropic_api_key="ant-test")
+    defaults.update(overrides)
+    return EvalConfig(**defaults)
+
+
+class TestMetricScore:
+    def test_passes_when_score_above_threshold(self):
+        m = MetricScore("faithfulness", score=0.90, threshold=0.85, min_threshold=0.75)
+        assert m.passes is True
+
+    def test_fails_when_score_below_threshold(self):
+        m = MetricScore("faithfulness", score=0.80, threshold=0.85, min_threshold=0.75)
+        assert m.passes is False
+
+    def test_above_minimum_when_between_min_and_target(self):
+        m = MetricScore("faithfulness", score=0.80, threshold=0.85, min_threshold=0.75)
+        assert m.above_minimum is True
+        assert m.status == "WARN"
+
+    def test_hard_fail_when_below_minimum(self):
+        m = MetricScore("faithfulness", score=0.70, threshold=0.85, min_threshold=0.75)
+        assert m.above_minimum is False
+        assert m.status == "FAIL"
+
+    def test_pass_status(self):
+        m = MetricScore("context_precision", score=0.85, threshold=0.80, min_threshold=0.70)
+        assert m.status == "PASS"
+
+
+class TestEvalResult:
+    def _pass_scores(self) -> list[MetricScore]:
+        return [
+            MetricScore("context_precision", 0.85, 0.80, 0.70),
+            MetricScore("context_recall", 0.80, 0.75, 0.65),
+            MetricScore("faithfulness", 0.90, 0.85, 0.75),
+            MetricScore("answer_relevance", 0.85, 0.80, 0.70),
+        ]
+
+    def test_all_pass_when_all_above_target(self):
+        result = EvalResult(self._pass_scores(), sample_count=10)
+        assert result.all_pass is True
+
+    def test_any_hard_fail_false_when_all_above_min(self):
+        scores = [MetricScore("faithfulness", 0.78, 0.85, 0.75)]  # warn only
+        result = EvalResult(scores, sample_count=5)
+        assert result.any_hard_fail is False
+
+    def test_any_hard_fail_true_when_below_min(self):
+        scores = [MetricScore("faithfulness", 0.60, 0.85, 0.75)]  # hard fail
+        result = EvalResult(scores, sample_count=5)
+        assert result.any_hard_fail is True
+
+    def test_above_minimum_false_when_one_hard_fail(self):
+        scores = self._pass_scores()
+        scores[0] = MetricScore("context_precision", 0.60, 0.80, 0.70)
+        result = EvalResult(scores, sample_count=10)
+        assert result.above_minimum is False
+
+    def test_to_summary_contains_all_metric_names(self):
+        result = EvalResult(self._pass_scores(), sample_count=10)
+        summary = result.to_summary()
+        assert "context_precision" in summary
+        assert "context_recall" in summary
+        assert "faithfulness" in summary
+        assert "answer_relevance" in summary
+
+    def test_to_summary_shows_overall_pass(self):
+        result = EvalResult(self._pass_scores(), sample_count=10)
+        assert "ALL PASS" in result.to_summary()
+
+    def test_to_summary_shows_hard_fail(self):
+        scores = [MetricScore("faithfulness", 0.50, 0.85, 0.75)]
+        result = EvalResult(scores, sample_count=5)
+        assert "HARD FAIL" in result.to_summary()
+
+    def test_to_github_summary_is_markdown_table(self):
+        result = EvalResult(self._pass_scores(), sample_count=10)
+        md = result.to_github_summary()
+        assert "| Metric |" in md
+        assert "context_precision" in md
+        assert "✅" in md
+
+    def test_sample_count_in_summary(self):
+        result = EvalResult(self._pass_scores(), sample_count=30)
+        assert "30" in result.to_summary()
+
+
+class TestRagasEvaluator:
+    def test_evaluate_empty_samples_raises(self):
+        cfg = _make_config()
+        evaluator = RagasEvaluator(cfg)
+        with pytest.raises(ValueError, match="empty"):
+            evaluator.evaluate([])
+
+    def test_build_result_applies_thresholds(self):
+        cfg = _make_config()
+        evaluator = RagasEvaluator(cfg)
+        scores = {
+            "context_precision": 0.82,
+            "context_recall": 0.77,
+            "faithfulness": 0.88,
+            "answer_relevance": 0.83,
+        }
+        result = evaluator._build_result(scores, sample_count=10)
+        assert result.sample_count == 10
+        assert len(result.metric_scores) == 4
+        assert result.all_pass is True
+
+    def test_build_result_hard_fail_when_below_min(self):
+        cfg = _make_config()
+        evaluator = RagasEvaluator(cfg)
+        scores = {
+            "context_precision": 0.60,  # below min=0.70
+            "context_recall": 0.77,
+            "faithfulness": 0.88,
+            "answer_relevance": 0.83,
+        }
+        result = evaluator._build_result(scores, sample_count=5)
+        assert result.any_hard_fail is True
+        assert not result.above_minimum
+
+    @patch("eval.ragas_evaluator.RagasEvaluator._run_ragas")
+    @patch("eval.ragas_evaluator.RagasEvaluator._to_ragas_samples")
+    def test_evaluate_calls_run_ragas_and_builds_result(self, mock_to_samples, mock_run_ragas):
+        mock_to_samples.return_value = ["stub_sample_1", "stub_sample_2"]
+        mock_run_ragas.return_value = {
+            "context_precision": 0.83,
+            "context_recall": 0.78,
+            "faithfulness": 0.91,
+            "answer_relevance": 0.85,
+        }
+        cfg = _make_config()
+        evaluator = RagasEvaluator(cfg)
+        samples = [_make_sample("gd-001"), _make_sample("gd-002")]
+        result = evaluator.evaluate(samples)
+        mock_to_samples.assert_called_once_with(samples)
+        mock_run_ragas.assert_called_once()
+        assert result.sample_count == 2
+        assert result.all_pass is True
+
+    def test_to_ragas_samples_maps_fields_correctly(self):
+        # Mock ragas.dataset_schema so test runs without ragas installed
+        import types
+        fake_ragas = types.ModuleType("ragas")
+        fake_schema = types.ModuleType("ragas.dataset_schema")
+
+        class FakeSingleTurnSample:
+            def __init__(self, **kwargs):
+                for k, v in kwargs.items():
+                    setattr(self, k, v)
+
+        fake_schema.SingleTurnSample = FakeSingleTurnSample
+        fake_ragas.dataset_schema = fake_schema
+
+        with patch.dict("sys.modules", {"ragas": fake_ragas, "ragas.dataset_schema": fake_schema}):
+            cfg = _make_config()
+            evaluator = RagasEvaluator(cfg)
+            samples = [_make_sample()]
+            ragas_samples = evaluator._to_ragas_samples(samples)
+
+        assert len(ragas_samples) == 1
+        s = ragas_samples[0]
+        assert s.user_input == "How many flood events occurred in Bangladesh?"
+        assert s.reference == "Over 100 floods between 1990 and 2021."
+        assert len(s.retrieved_contexts) == 2
+
+    def test_to_ragas_samples_empty_contexts_padded(self):
+        import types
+        fake_ragas = types.ModuleType("ragas")
+        fake_schema = types.ModuleType("ragas.dataset_schema")
+
+        class FakeSingleTurnSample:
+            def __init__(self, **kwargs):
+                for k, v in kwargs.items():
+                    setattr(self, k, v)
+
+        fake_schema.SingleTurnSample = FakeSingleTurnSample
+        fake_ragas.dataset_schema = fake_schema
+
+        with patch.dict("sys.modules", {"ragas": fake_ragas, "ragas.dataset_schema": fake_schema}):
+            cfg = _make_config()
+            evaluator = RagasEvaluator(cfg)
+            sample = EvalSample("gd-001", "Q?", "GT", contexts=[], answer="A")
+            ragas_samples = evaluator._to_ragas_samples([sample])
+
+        assert ragas_samples[0].retrieved_contexts == [""]


### PR DESCRIPTION
## What
Adds the Phase 4 evaluation framework for TerraQuery: a 30-question golden dataset, Python RAGAS evaluator with cross-provider scoring, Java live-LLM eval tests, and CI/CD integration (nightly full eval + PR canary).

## Why
Closes #30. Establishes objective, bias-free quality measurement using generator (OpenAI gpt-4o-mini) ≠ evaluator (Anthropic claude-haiku) to eliminate self-evaluation bias, with hard-fail thresholds to prevent silent regressions.

## Changes

**Golden dataset (`terra-mcp/eval/golden_dataset.json`)**
- 30 Q&A pairs in 5 categories: event counts, death tolls, economic damage, disaster type comparisons, trend analysis
- Each entry: `id`, `question`, `ground_truth`, `context_docs`, `verification_sources`
- Human-verified against Wikipedia + EM-DAT

**Python eval framework (`terra-mcp/eval/`)**
- `eval_config.py` — `EvalThresholds` (frozen dataclass) + `EvalConfig`; thresholds: Context Precision ≥0.80, Recall ≥0.75, Faithfulness ≥0.85, Answer Relevance ≥0.80; min floor = target − 0.10
- `answer_generator.py` — `McpDirectRetriever` (imports terra-mcp search directly, no HTTP), `AnswerGenerator` (prompt-builds + calls generator LLM), `build_openai_generator_fn`
- `ragas_evaluator.py` — `RagasEvaluator` using `LLMContextPrecisionWithReference`, `LLMContextRecall`, `Faithfulness`, `ResponseRelevancy`; `EvalResult.to_github_summary()` writes markdown to `$GITHUB_STEP_SUMMARY`
- `eval_runner.py` — CLI: `--subset canary|full`; exit 0 (all pass) / 1 (hard fail) / 2 (warn)
- `requirements-eval.txt` — adds `ragas>=0.2.0`, `langchain-openai`, `langchain-anthropic`, `openai`, `anthropic`

**Python tests (`terra-mcp/tests/eval/`) — 45 tests, all green**
- `test_eval_config.py` — threshold math, `from_env`, `validate`
- `test_answer_generator.py` — retriever, context formatting, batch generation, error handling
- `test_ragas_evaluator.py` — `MetricScore` / `EvalResult` logic, `_build_result`, `_to_ragas_samples` (ragas mocked so no install required)

**Java live-test harness (`terra-infrastructure/`)**
- `live/EvalConfig.java` — `@TestConfiguration`; `@Bean("generatorChatModel")` = OpenAI, `@Bean("evaluatorChatModel")` = Anthropic
- `live/LiveLlmEvalTest.java` — `@Tag("live-llm")` parameterized over `goldenQuestions()`; two test methods: non-empty coherent answers + cross-provider relevance scoring (1–5 scale, must be ≥3); `eval.subset` system property selects 10 or 30 questions
- `src/test/resources/application-live-test.yml` — MCP at `localhost:8200`, `gpt-4o-mini` generator, `claude-haiku` evaluator, relaxed guardrails for live testing
- `src/test/resources/golden_dataset.json` — classpath copy for Java test loader
- `build.gradle.kts` — `liveTest` task now forwards `eval.subset` system property

**CI/CD**
- `eval-terra-query.yml` (new) — nightly at 02:00 UTC + `workflow_dispatch` + on-eval-data-change trigger; starts terra-mcp, runs `eval_runner.py --subset full`, publishes RAGAS table to GH Actions summary, uploads `ragas-results.json`
- `ci-terra-query.yml` (updated) — adds `ragas-canary` job on PRs (first-party forks only): 10-question subset, publishes inline summary