### PR TITLE
feat(terra-query): overhaul GitHub Actions workflows

### DIFF
--- a/.github/workflows/terra-query-build-deploy.yml
+++ b/.github/workflows/terra-query-build-deploy.yml
@@ -1,0 +1,71 @@
+name: terra-query: Build & Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch, tag, or SHA to build and deploy
+        default: main
+        required: true
+      services:
+        description: "Services to build (comma-separated: backend,mcp,ui)"
+        default: "backend,mcp,ui"
+        required: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_OWNER: ${{ github.repository_owner }}
+
+jobs:
+  build-and-deploy:
+    name: Build & Push Docker Images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push terra-infrastructure image
+        if: contains(inputs.services, 'backend')
+        uses: docker/build-push-action@v6
+        with:
+          context: ai-architect/terra-query
+          file: ai-architect/terra-query/terra-infrastructure/Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/terra-infrastructure:latest
+          cache-from: type=gha,scope=terra-infrastructure
+          cache-to: type=gha,mode=max,scope=terra-infrastructure
+
+      - name: Build and push terra-mcp image
+        if: contains(inputs.services, 'mcp')
+        uses: docker/build-push-action@v6
+        with:
+          context: ai-architect/terra-query/terra-mcp
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/terra-mcp:latest
+          cache-from: type=gha,scope=terra-mcp
+          cache-to: type=gha,mode=max,scope=terra-mcp
+
+      - name: Build and push terra-ui image
+        if: contains(inputs.services, 'ui')
+        uses: docker/build-push-action@v6
+        with:
+          context: ai-architect/terra-query/terra-ui
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/terra-ui:latest
+          cache-from: type=gha,scope=terra-ui
+          cache-to: type=gha,mode=max,scope=terra-ui

--- a/.github/workflows/terra-query-ci.yml
+++ b/.github/workflows/terra-query-ci.yml
@@ -1,4 +1,4 @@
-name: CI — terra-query - Backend
+name: terra-query: CI
 
 on:
   push:
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Java 25
         uses: actions/setup-java@v4
@@ -39,11 +39,8 @@ jobs:
       - name: Run terra-core unit tests (target ≥90% coverage)
         run: ./gradlew :terra-core:test --info
 
-      - name: Run terra-infrastructure unit + integration tests
+      - name: Run terra-infrastructure unit + integration tests (includes ArchUnit)
         run: ./gradlew :terra-infrastructure:test --info
-
-      - name: Run ArchUnit boundary checks (5 rules)
-        run: ./gradlew :terra-infrastructure:test --tests "*ArchitectureTest" --info
 
       - name: Upload test reports
         if: always()
@@ -69,7 +66,23 @@ jobs:
         working-directory: ai-architect/terra-query/terra-mcp
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
+      - name: Check required API keys
+        id: check-secrets
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          missing=()
+          [[ -z "$OPENAI_API_KEY" ]] && missing+=("OPENAI_API_KEY")
+          [[ -z "$ANTHROPIC_API_KEY" ]] && missing+=("ANTHROPIC_API_KEY")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::warning::Missing required secrets: ${missing[*]}. RAGAS canary eval will be skipped."
+            echo "has_keys=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_keys=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
@@ -81,10 +94,12 @@ jobs:
         run: pip install -r requirements-eval.txt
 
       - name: Start terra-mcp server
+        if: steps.check-secrets.outputs.has_keys == 'true'
         working-directory: ai-architect/terra-query
         run: docker compose up -d terra-mcp
 
       - name: Wait for terra-mcp healthy
+        if: steps.check-secrets.outputs.has_keys == 'true'
         working-directory: ai-architect/terra-query
         run: |
           for i in $(seq 1 30); do
@@ -94,6 +109,7 @@ jobs:
           done
 
       - name: Run RAGAS canary eval (10 questions)
+        if: steps.check-secrets.outputs.has_keys == 'true'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -133,7 +149,7 @@ jobs:
     needs: build-and-test
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Java 25
         uses: actions/setup-java@v4
@@ -144,7 +160,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Run PIT mutation tests (terra-core, target ≥70% kill)
+      - name: Run PIT mutation tests (terra-core, target ≥55% kill)
         run: ./gradlew :terra-core:pitest
 
       - name: Upload PIT report

--- a/.github/workflows/terra-query-live-eval.yml
+++ b/.github/workflows/terra-query-live-eval.yml
@@ -1,4 +1,4 @@
-name: Live LLM Test Suite — terra-query
+name: terra-query: Live LLM Eval
 
 on:
   schedule:
@@ -25,7 +25,23 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
+      - name: Check required API keys
+        id: check-secrets
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          missing=()
+          [[ -z "$OPENAI_API_KEY" ]] && missing+=("OPENAI_API_KEY")
+          [[ -z "$ANTHROPIC_API_KEY" ]] && missing+=("ANTHROPIC_API_KEY")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::warning::Missing required secrets: ${missing[*]}. Live LLM eval will be skipped."
+            echo "has_keys=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_keys=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Set up Java 25
         uses: actions/setup-java@v4
@@ -37,9 +53,11 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Start terra-mcp server with real data
+        if: steps.check-secrets.outputs.has_keys == 'true'
         run: docker compose up -d terra-mcp
 
       - name: Wait for terra-mcp healthy
+        if: steps.check-secrets.outputs.has_keys == 'true'
         run: |
           for i in $(seq 1 30); do
             curl -sf http://localhost:8200/health && echo "MCP server ready" && break
@@ -48,6 +66,7 @@ jobs:
           done
 
       - name: Run live LLM answer quality tests
+        if: steps.check-secrets.outputs.has_keys == 'true'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/terra-query-mcp-ci.yml
+++ b/.github/workflows/terra-query-mcp-ci.yml
@@ -1,0 +1,91 @@
+name: terra-query: MCP CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "ai-architect/terra-query/terra-mcp/**"
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "ai-architect/terra-query/terra-mcp/**"
+
+defaults:
+  run:
+    working-directory: ai-architect/terra-query/terra-mcp
+
+jobs:
+  lint-and-typecheck:
+    name: Lint & Type Check (Python 3.11)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dev dependencies
+        run: pip install -r requirements-dev.txt ruff mypy
+
+      - name: Run ruff lint
+        run: ruff check .
+
+      - name: Run ruff format check
+        run: ruff format --check .
+
+      - name: Run mypy type check
+        run: mypy server.py tools/ search/ validation/ --ignore-missing-imports
+
+  unit-tests:
+    name: Unit Tests (Python 3.11)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dev dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Run unit tests
+        run: pytest tests/unit/ -v --tb=short --cov=. --cov-report=xml --cov-report=term-missing
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mcp-coverage-${{ github.run_number }}
+          path: ai-architect/terra-query/terra-mcp/coverage.xml
+
+  integration-tests:
+    name: Integration Tests (Python 3.11)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: unit-tests
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dev dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Run integration tests
+        run: pytest tests/integration/ -v --tb=short

--- a/.github/workflows/terra-query-perf.yml
+++ b/.github/workflows/terra-query-perf.yml
@@ -1,0 +1,84 @@
+name: terra-query: Performance Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      users:
+        description: "Number of concurrent users"
+        required: false
+        default: "10"
+      duration:
+        description: "Test duration in seconds"
+        required: false
+        default: "60"
+
+defaults:
+  run:
+    working-directory: ai-architect/terra-query
+
+jobs:
+  gatling:
+    name: Gatling Baseline Simulation (${{ inputs.users }} users, ${{ inputs.duration }}s)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check required API keys
+        id: check-secrets
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          missing=()
+          [[ -z "$OPENAI_API_KEY" ]] && missing+=("OPENAI_API_KEY")
+          [[ -z "$ANTHROPIC_API_KEY" ]] && missing+=("ANTHROPIC_API_KEY")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::warning::Missing required secrets: ${missing[*]}. Perf test requires a running LLM-backed service — will be skipped."
+            echo "has_keys=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_keys=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up Java 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: "25"
+          distribution: temurin
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Start full stack
+        if: steps.check-secrets.outputs.has_keys == 'true'
+        run: docker compose up -d terra-mcp terra-infrastructure
+
+      - name: Wait for terra-infrastructure healthy
+        if: steps.check-secrets.outputs.has_keys == 'true'
+        run: |
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:8080/actuator/health && echo "Backend ready" && break
+            echo "Waiting for backend ($i/30)..."
+            sleep 10
+          done
+
+      - name: Run Gatling simulation
+        if: steps.check-secrets.outputs.has_keys == 'true'
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GATLING_USERS: ${{ inputs.users }}
+          GATLING_DURATION: ${{ inputs.duration }}
+        run: ./gradlew :terra-infrastructure:gatlingRun-com.aiarchitect.terraquery.TerraQueryBaselineSimulation
+
+      - name: Upload Gatling report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gatling-report-${{ github.run_number }}
+          path: ai-architect/terra-query/terra-infrastructure/build/reports/gatling/
+
+      - name: Tear down stack
+        if: always()
+        run: docker compose down

--- a/.github/workflows/terra-query-pitest.yml
+++ b/.github/workflows/terra-query-pitest.yml
@@ -1,0 +1,43 @@
+name: terra-query: Mutation Tests
+
+on:
+  schedule:
+    - cron: "0 3 * * 6"   # Every Saturday at 03:00 UTC
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: ai-architect/terra-query
+
+jobs:
+  pitest:
+    name: PIT Mutation Tests (terra-core ≥55% + terra-infrastructure ≥50%)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Java 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: "25"
+          distribution: temurin
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run PIT — terra-core (target ≥55% kill)
+        run: ./gradlew :terra-core:pitest
+
+      - name: Run PIT — terra-infrastructure (target ≥50% kill)
+        run: ./gradlew :terra-infrastructure:pitest
+
+      - name: Upload PIT reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pitest-reports-${{ github.run_number }}
+          path: |
+            ai-architect/terra-query/terra-core/build/reports/pitest/
+            ai-architect/terra-query/terra-infrastructure/build/reports/pitest/

--- a/.github/workflows/terra-query-ragas-eval.yml
+++ b/.github/workflows/terra-query-ragas-eval.yml
@@ -1,4 +1,4 @@
-name: Eval — TerraQuery RAGAS Evaluation
+name: terra-query: RAGAS Eval
 
 on:
   schedule:
@@ -25,12 +25,28 @@ defaults:
 
 jobs:
   ragas-eval:
-    name: RAGAS Evaluation (${{ github.event.inputs.subset || 'full' }})
+    name: RAGAS Eval (${{ github.event_name == 'push' && 'canary/push' || github.event.inputs.subset || 'full/nightly' }})
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
+      - name: Check required API keys
+        id: check-secrets
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          missing=()
+          [[ -z "$OPENAI_API_KEY" ]] && missing+=("OPENAI_API_KEY")
+          [[ -z "$ANTHROPIC_API_KEY" ]] && missing+=("ANTHROPIC_API_KEY")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::warning::Missing required secrets: ${missing[*]}. RAGAS eval will be skipped."
+            echo "has_keys=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_keys=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
@@ -42,10 +58,12 @@ jobs:
         run: pip install -r requirements-eval.txt
 
       - name: Start terra-mcp server
+        if: steps.check-secrets.outputs.has_keys == 'true'
         working-directory: ai-architect/terra-query
         run: docker compose up -d terra-mcp
 
       - name: Wait for terra-mcp healthy
+        if: steps.check-secrets.outputs.has_keys == 'true'
         working-directory: ai-architect/terra-query
         run: |
           for i in $(seq 1 30); do
@@ -55,10 +73,12 @@ jobs:
           done
 
       - name: Run RAGAS evaluation
+        if: steps.check-secrets.outputs.has_keys == 'true'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          EVAL_SUBSET: ${{ github.event.inputs.subset || 'full' }}
+          # Push events run canary only (cheap fast check); schedule/dispatch use full
+          EVAL_SUBSET: ${{ github.event_name == 'push' && 'canary' || github.event.inputs.subset || 'full' }}
         run: |
           python -m eval.eval_runner \
             --subset "$EVAL_SUBSET" \


### PR DESCRIPTION
- Rename all 3 existing workflows to terra-query-* prefix for discoverability
- Fix ci: remove redundant ArchUnit step (covered by infra test run); fix pitest label inconsistency
- Fix ragas-eval: push trigger now runs canary subset instead of full 30-question eval
- Add terra-query-build-deploy.yml: manual Docker build+push for all 3 services (backend/mcp/ui)
- Add terra-query-mcp-ci.yml: Python CI with ruff lint, mypy, unit + integration tests
- Add terra-query-pitest.yml: mutation tests for both terra-core (≥55%) and terra-infrastructure (≥50%), manual + weekly cron
- Add terra-query-perf.yml: manual-only Gatling simulation with users/duration inputs
- Add check-secrets step to all LLM-dependent jobs: warns on missing API keys and skips affected steps
- Bump actions/checkout to v6 across all terra-query workflows